### PR TITLE
ci: use `node_modules` path instead of `~/.npm`

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -21,10 +21,11 @@ jobs:
               id: npm_cache
               uses: actions/cache@v2
               with:
-                  path: ~/.npm
+                  path: '**/node_modules'
                   key: node${{ secrets.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
 
             - name: Install dependencies
+              if: steps.npm_cache.outputs.cache-hit != 'true'
               run: npm ci
 
             - name: Lint and fix code
@@ -59,10 +60,11 @@ jobs:
               id: npm_cache
               uses: actions/cache@v2
               with:
-                  path: ~/.npm
+                  path: '**/node_modules'
                   key: node${{ secrets.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
 
             - name: Install dependencies
+              if: steps.npm_cache.outputs.cache-hit != 'true'
               run: npm ci
 
             - name: Build the CLI

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,10 +25,11 @@ jobs:
               id: npm_cache
               uses: actions/cache@v2
               with:
-                  path: ~/.npm
+                  path: '**/node_modules'
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
             - name: Install NPM dependencies
+              if: steps.npm_cache.outputs.cache-hit != 'true'
               run: npm ci
 
             - name: Cache Cypress binary


### PR DESCRIPTION
Same as in `clarify`