### PR TITLE
chore: remove `tailwind-config-viewer`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
                 "rollup-plugin-postcss": "^4.0.0",
                 "storybook-builder-vite": "^0.0.12",
                 "storybook-dark-mode": "^1.0.8",
-                "tailwind-config-viewer": "^1.6.2",
                 "tailwindcss": "^2.2.7",
                 "ts-node": "^10.1.0",
                 "typescript": "^4.3.5",
@@ -2515,50 +2514,6 @@
             "engines": {
                 "node": ">= 10.14.2"
             }
-        },
-        "node_modules/@koa/router": {
-            "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/@koa/router/-/router-9.4.0.tgz",
-            "integrity": "sha512-dOOXgzqaDoHu5qqMEPLKEgLz5CeIA7q8+1W62mCvFVCOqeC71UoTGJ4u1xUSOpIl2J1x2pqrNULkFteUeZW3/A==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.1.1",
-                "http-errors": "^1.7.3",
-                "koa-compose": "^4.1.0",
-                "methods": "^1.1.2",
-                "path-to-regexp": "^6.1.0"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            }
-        },
-        "node_modules/@koa/router/node_modules/http-errors": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-            "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-            "dev": true,
-            "dependencies": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": ">= 1.5.0 < 2",
-                "toidentifier": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@koa/router/node_modules/path-to-regexp": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
-            "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
-            "dev": true
-        },
-        "node_modules/@koa/router/node_modules/setprototypeof": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-            "dev": true
         },
         "node_modules/@mdx-js/loader": {
             "version": "1.6.22",
@@ -7064,12 +7019,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/any-promise": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-            "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-            "dev": true
-        },
         "node_modules/anymatch": {
             "version": "3.1.2",
             "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
@@ -8321,19 +8270,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/cache-content-type": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
-            "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
-            "dev": true,
-            "dependencies": {
-                "mime-types": "^2.1.18",
-                "ylru": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
         "node_modules/cachedir": {
             "version": "2.3.0",
             "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
@@ -8773,16 +8709,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true,
-            "engines": {
-                "iojs": ">= 1.0.0",
-                "node": ">= 0.12.0"
-            }
-        },
         "node_modules/coa": {
             "version": "2.0.2",
             "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
@@ -9124,28 +9050,6 @@
             "version": "1.0.6",
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
             "dev": true
-        },
-        "node_modules/cookies": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
-            "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
-            "dev": true,
-            "dependencies": {
-                "depd": "~2.0.0",
-                "keygrip": "~1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/cookies/node_modules/depd": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/copy-concurrently": {
             "version": "1.0.5",
@@ -10243,12 +10147,6 @@
         "node_modules/dedent": {
             "version": "0.7.0",
             "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-            "dev": true
-        },
-        "node_modules/deep-equal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
             "dev": true
         },
         "node_modules/deep-is": {
@@ -13860,19 +13758,6 @@
                 "entities": "^2.0.0"
             }
         },
-        "node_modules/http-assert": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.4.1.tgz",
-            "integrity": "sha512-rdw7q6GTlibqVVbXr0CKelfV5iY8G2HqEUkhSk297BMbSpSL8crXC+9rjKoMcZZEsksX30le6f/4ul4E28gegw==",
-            "dev": true,
-            "dependencies": {
-                "deep-equal": "~1.0.1",
-                "http-errors": "~1.7.2"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/http-errors": {
             "version": "1.7.2",
             "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
@@ -14512,21 +14397,6 @@
             "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
             "dev": true
         },
-        "node_modules/is-generator-function": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-            "dev": true,
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-glob": {
             "version": "4.0.1",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
@@ -15130,18 +15000,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/keygrip": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-            "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-            "dev": true,
-            "dependencies": {
-                "tsscmp": "1.0.6"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/kind-of": {
             "version": "6.0.3",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
@@ -15173,150 +15031,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/koa": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/koa/-/koa-2.13.1.tgz",
-            "integrity": "sha512-Lb2Dloc72auj5vK4X4qqL7B5jyDPQaZucc9sR/71byg7ryoD1NCaCm63CShk9ID9quQvDEi1bGR/iGjCG7As3w==",
-            "dev": true,
-            "dependencies": {
-                "accepts": "^1.3.5",
-                "cache-content-type": "^1.0.0",
-                "content-disposition": "~0.5.2",
-                "content-type": "^1.0.4",
-                "cookies": "~0.8.0",
-                "debug": "~3.1.0",
-                "delegates": "^1.0.0",
-                "depd": "^2.0.0",
-                "destroy": "^1.0.4",
-                "encodeurl": "^1.0.2",
-                "escape-html": "^1.0.3",
-                "fresh": "~0.5.2",
-                "http-assert": "^1.3.0",
-                "http-errors": "^1.6.3",
-                "is-generator-function": "^1.0.7",
-                "koa-compose": "^4.1.0",
-                "koa-convert": "^1.2.0",
-                "on-finished": "^2.3.0",
-                "only": "~0.0.2",
-                "parseurl": "^1.3.2",
-                "statuses": "^1.5.0",
-                "type-is": "^1.6.16",
-                "vary": "^1.1.2"
-            },
-            "engines": {
-                "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
-            }
-        },
-        "node_modules/koa-compose": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
-            "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-            "dev": true
-        },
-        "node_modules/koa-convert": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
-            "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
-            "dev": true,
-            "dependencies": {
-                "co": "^4.6.0",
-                "koa-compose": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/koa-convert/node_modules/koa-compose": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
-            "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
-            "dev": true,
-            "dependencies": {
-                "any-promise": "^1.1.0"
-            }
-        },
-        "node_modules/koa-send": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
-            "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.1.1",
-                "http-errors": "^1.7.3",
-                "resolve-path": "^1.4.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/koa-send/node_modules/http-errors": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-            "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-            "dev": true,
-            "dependencies": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": ">= 1.5.0 < 2",
-                "toidentifier": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/koa-send/node_modules/setprototypeof": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-            "dev": true
-        },
-        "node_modules/koa-static": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
-            "integrity": "sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^3.1.0",
-                "koa-send": "^5.0.0"
-            },
-            "engines": {
-                "node": ">= 7.6.0"
-            }
-        },
-        "node_modules/koa-static/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/koa/node_modules/debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/koa/node_modules/depd": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/koa/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
         },
         "node_modules/language-subtag-registry": {
             "version": "0.3.21",
@@ -16661,12 +16375,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/only": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-            "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=",
-            "dev": true
-        },
         "node_modules/open": {
             "version": "7.4.2",
             "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
@@ -17220,38 +16928,6 @@
                 "hey-listen": "^1.0.8",
                 "style-value-types": "4.1.4",
                 "tslib": "^2.1.0"
-            }
-        },
-        "node_modules/portfinder": {
-            "version": "1.0.28",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
-            "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
-            "dev": true,
-            "dependencies": {
-                "async": "^2.6.2",
-                "debug": "^3.1.1",
-                "mkdirp": "^0.5.5"
-            },
-            "engines": {
-                "node": ">= 0.12.0"
-            }
-        },
-        "node_modules/portfinder/node_modules/async": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-            "dev": true,
-            "dependencies": {
-                "lodash": "^4.17.14"
-            }
-        },
-        "node_modules/portfinder/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "^2.1.1"
             }
         },
         "node_modules/posix-character-classes": {
@@ -19975,23 +19651,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/replace-in-file": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.2.0.tgz",
-            "integrity": "sha512-Im2AF9G/qgkYneOc9QwWwUS/efyyonTUBvzXS2VXuxPawE5yQIjT/e6x4CTijO0Quq48lfAujuo+S89RR2TP2Q==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.1.0",
-                "glob": "^7.1.6",
-                "yargs": "^16.2.0"
-            },
-            "bin": {
-                "replace-in-file": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/request-progress": {
             "version": "3.0.0",
             "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
@@ -20035,46 +19694,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/resolve-path": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
-            "integrity": "sha1-xL2p9e+y/OZSR4c6s2u02DT+Fvc=",
-            "dev": true,
-            "dependencies": {
-                "http-errors": "~1.6.2",
-                "path-is-absolute": "1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/resolve-path/node_modules/http-errors": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-            "dev": true,
-            "dependencies": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/resolve-path/node_modules/inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
-        },
-        "node_modules/resolve-path/node_modules/setprototypeof": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-            "dev": true
         },
         "node_modules/resolve-url": {
             "version": "0.2.1",
@@ -21810,32 +21429,6 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
-        "node_modules/tailwind-config-viewer": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/tailwind-config-viewer/-/tailwind-config-viewer-1.6.2.tgz",
-            "integrity": "sha512-GEysLLUkHF/CW7idElDIsCUWwNfE5v4SpecNv5Z10KGtX8ez2ZUlHep/bJZ4E/Hk+IqJQt2hChFx43VkDN7WtQ==",
-            "dev": true,
-            "dependencies": {
-                "@koa/router": "^9.0.1",
-                "commander": "^6.0.0",
-                "fs-extra": "^9.0.1",
-                "koa": "^2.12.0",
-                "koa-static": "^5.0.0",
-                "open": "^7.0.4",
-                "portfinder": "^1.0.26",
-                "replace-in-file": "^6.1.0"
-            },
-            "bin": {
-                "tailwind-config-viewer": "cli/index.js",
-                "tailwindcss-config-viewer": "cli/index.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "peerDependencies": {
-                "tailwindcss": "1 || 2 || 2.0.1-compat"
-            }
-        },
         "node_modules/tailwindcss": {
             "version": "2.2.11",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.11.tgz",
@@ -22488,15 +22081,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "node_modules/tsscmp": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-            "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6.x"
-            }
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -24270,15 +23854,6 @@
                 "fd-slicer": "~1.1.0"
             }
         },
-        "node_modules/ylru": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.2.1.tgz",
-            "integrity": "sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "node_modules/yn": {
             "version": "3.1.1",
             "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
@@ -26013,46 +25588,6 @@
                 "@types/node": "*",
                 "@types/yargs": "^15.0.0",
                 "chalk": "^4.0.0"
-            }
-        },
-        "@koa/router": {
-            "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/@koa/router/-/router-9.4.0.tgz",
-            "integrity": "sha512-dOOXgzqaDoHu5qqMEPLKEgLz5CeIA7q8+1W62mCvFVCOqeC71UoTGJ4u1xUSOpIl2J1x2pqrNULkFteUeZW3/A==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.1.1",
-                "http-errors": "^1.7.3",
-                "koa-compose": "^4.1.0",
-                "methods": "^1.1.2",
-                "path-to-regexp": "^6.1.0"
-            },
-            "dependencies": {
-                "http-errors": {
-                    "version": "1.8.0",
-                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-                    "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-                    "dev": true,
-                    "requires": {
-                        "depd": "~1.1.2",
-                        "inherits": "2.0.4",
-                        "setprototypeof": "1.2.0",
-                        "statuses": ">= 1.5.0 < 2",
-                        "toidentifier": "1.0.0"
-                    }
-                },
-                "path-to-regexp": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
-                    "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
-                    "dev": true
-                },
-                "setprototypeof": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-                    "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-                    "dev": true
-                }
             }
         },
         "@mdx-js/loader": {
@@ -29386,12 +28921,6 @@
                 "entities": "^2.0.0"
             }
         },
-        "any-promise": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-            "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-            "dev": true
-        },
         "anymatch": {
             "version": "3.1.2",
             "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
@@ -30367,16 +29896,6 @@
                 "unset-value": "^1.0.0"
             }
         },
-        "cache-content-type": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
-            "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
-            "dev": true,
-            "requires": {
-                "mime-types": "^2.1.18",
-                "ylru": "^1.2.0"
-            }
-        },
         "cachedir": {
             "version": "2.3.0",
             "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
@@ -30700,12 +30219,6 @@
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
             "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
         },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
-        },
         "coa": {
             "version": "2.0.2",
             "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
@@ -30988,24 +30501,6 @@
             "version": "1.0.6",
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
             "dev": true
-        },
-        "cookies": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
-            "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
-            "dev": true,
-            "requires": {
-                "depd": "~2.0.0",
-                "keygrip": "~1.1.0"
-            },
-            "dependencies": {
-                "depd": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-                    "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-                    "dev": true
-                }
-            }
         },
         "copy-concurrently": {
             "version": "1.0.5",
@@ -31864,12 +31359,6 @@
         "dedent": {
             "version": "0.7.0",
             "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-            "dev": true
-        },
-        "deep-equal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
             "dev": true
         },
         "deep-is": {
@@ -34692,16 +34181,6 @@
                 "entities": "^2.0.0"
             }
         },
-        "http-assert": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.4.1.tgz",
-            "integrity": "sha512-rdw7q6GTlibqVVbXr0CKelfV5iY8G2HqEUkhSk297BMbSpSL8crXC+9rjKoMcZZEsksX30le6f/4ul4E28gegw==",
-            "dev": true,
-            "requires": {
-                "deep-equal": "~1.0.1",
-                "http-errors": "~1.7.2"
-            }
-        },
         "http-errors": {
             "version": "1.7.2",
             "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
@@ -35152,15 +34631,6 @@
             "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
             "dev": true
         },
-        "is-generator-function": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-            "dev": true,
-            "requires": {
-                "has-tostringtag": "^1.0.0"
-            }
-        },
         "is-glob": {
             "version": "4.0.1",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
@@ -35602,15 +35072,6 @@
             "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
             "dev": true
         },
-        "keygrip": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-            "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-            "dev": true,
-            "requires": {
-                "tsscmp": "1.0.6"
-            }
-        },
         "kind-of": {
             "version": "6.0.3",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
@@ -35633,140 +35094,6 @@
             "version": "2.0.4",
             "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
             "dev": true
-        },
-        "koa": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/koa/-/koa-2.13.1.tgz",
-            "integrity": "sha512-Lb2Dloc72auj5vK4X4qqL7B5jyDPQaZucc9sR/71byg7ryoD1NCaCm63CShk9ID9quQvDEi1bGR/iGjCG7As3w==",
-            "dev": true,
-            "requires": {
-                "accepts": "^1.3.5",
-                "cache-content-type": "^1.0.0",
-                "content-disposition": "~0.5.2",
-                "content-type": "^1.0.4",
-                "cookies": "~0.8.0",
-                "debug": "~3.1.0",
-                "delegates": "^1.0.0",
-                "depd": "^2.0.0",
-                "destroy": "^1.0.4",
-                "encodeurl": "^1.0.2",
-                "escape-html": "^1.0.3",
-                "fresh": "~0.5.2",
-                "http-assert": "^1.3.0",
-                "http-errors": "^1.6.3",
-                "is-generator-function": "^1.0.7",
-                "koa-compose": "^4.1.0",
-                "koa-convert": "^1.2.0",
-                "on-finished": "^2.3.0",
-                "only": "~0.0.2",
-                "parseurl": "^1.3.2",
-                "statuses": "^1.5.0",
-                "type-is": "^1.6.16",
-                "vary": "^1.1.2"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "depd": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-                    "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
-            }
-        },
-        "koa-compose": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
-            "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-            "dev": true
-        },
-        "koa-convert": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
-            "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
-            "dev": true,
-            "requires": {
-                "co": "^4.6.0",
-                "koa-compose": "^3.0.0"
-            },
-            "dependencies": {
-                "koa-compose": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
-                    "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
-                    "dev": true,
-                    "requires": {
-                        "any-promise": "^1.1.0"
-                    }
-                }
-            }
-        },
-        "koa-send": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
-            "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.1.1",
-                "http-errors": "^1.7.3",
-                "resolve-path": "^1.4.0"
-            },
-            "dependencies": {
-                "http-errors": {
-                    "version": "1.8.0",
-                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-                    "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-                    "dev": true,
-                    "requires": {
-                        "depd": "~1.1.2",
-                        "inherits": "2.0.4",
-                        "setprototypeof": "1.2.0",
-                        "statuses": ">= 1.5.0 < 2",
-                        "toidentifier": "1.0.0"
-                    }
-                },
-                "setprototypeof": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-                    "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-                    "dev": true
-                }
-            }
-        },
-        "koa-static": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
-            "integrity": "sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==",
-            "dev": true,
-            "requires": {
-                "debug": "^3.1.0",
-                "koa-send": "^5.0.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                }
-            }
         },
         "language-subtag-registry": {
             "version": "0.3.21",
@@ -36830,12 +36157,6 @@
                 "mimic-fn": "^2.1.0"
             }
         },
-        "only": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-            "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=",
-            "dev": true
-        },
         "open": {
             "version": "7.4.2",
             "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
@@ -37255,37 +36576,6 @@
                 "hey-listen": "^1.0.8",
                 "style-value-types": "4.1.4",
                 "tslib": "^2.1.0"
-            }
-        },
-        "portfinder": {
-            "version": "1.0.28",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
-            "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
-            "dev": true,
-            "requires": {
-                "async": "^2.6.2",
-                "debug": "^3.1.1",
-                "mkdirp": "^0.5.5"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "2.6.3",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-                    "dev": true,
-                    "requires": {
-                        "lodash": "^4.17.14"
-                    }
-                },
-                "debug": {
-                    "version": "3.2.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                }
             }
         },
         "posix-character-classes": {
@@ -39290,17 +38580,6 @@
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
-        "replace-in-file": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.2.0.tgz",
-            "integrity": "sha512-Im2AF9G/qgkYneOc9QwWwUS/efyyonTUBvzXS2VXuxPawE5yQIjT/e6x4CTijO0Quq48lfAujuo+S89RR2TP2Q==",
-            "dev": true,
-            "requires": {
-                "chalk": "^4.1.0",
-                "glob": "^7.1.6",
-                "yargs": "^16.2.0"
-            }
-        },
         "request-progress": {
             "version": "3.0.0",
             "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
@@ -39332,42 +38611,6 @@
             "version": "5.0.0",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true
-        },
-        "resolve-path": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
-            "integrity": "sha1-xL2p9e+y/OZSR4c6s2u02DT+Fvc=",
-            "dev": true,
-            "requires": {
-                "http-errors": "~1.6.2",
-                "path-is-absolute": "1.0.1"
-            },
-            "dependencies": {
-                "http-errors": {
-                    "version": "1.6.3",
-                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-                    "dev": true,
-                    "requires": {
-                        "depd": "~1.1.2",
-                        "inherits": "2.0.3",
-                        "setprototypeof": "1.1.0",
-                        "statuses": ">= 1.4.0 < 2"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true
-                },
-                "setprototypeof": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-                    "dev": true
-                }
-            }
         },
         "resolve-url": {
             "version": "0.2.1",
@@ -40767,22 +40010,6 @@
                 }
             }
         },
-        "tailwind-config-viewer": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/tailwind-config-viewer/-/tailwind-config-viewer-1.6.2.tgz",
-            "integrity": "sha512-GEysLLUkHF/CW7idElDIsCUWwNfE5v4SpecNv5Z10KGtX8ez2ZUlHep/bJZ4E/Hk+IqJQt2hChFx43VkDN7WtQ==",
-            "dev": true,
-            "requires": {
-                "@koa/router": "^9.0.1",
-                "commander": "^6.0.0",
-                "fs-extra": "^9.0.1",
-                "koa": "^2.12.0",
-                "koa-static": "^5.0.0",
-                "open": "^7.0.4",
-                "portfinder": "^1.0.26",
-                "replace-in-file": "^6.1.0"
-            }
-        },
         "tailwindcss": {
             "version": "2.2.11",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.11.tgz",
@@ -41256,12 +40483,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "tsscmp": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-            "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-            "dev": true
         },
         "tsutils": {
             "version": "3.21.0",
@@ -42643,12 +41864,6 @@
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
             }
-        },
-        "ylru": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.2.1.tgz",
-            "integrity": "sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==",
-            "dev": true
         },
         "yn": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
         "rollup-plugin-postcss": "^4.0.0",
         "storybook-builder-vite": "^0.0.12",
         "storybook-dark-mode": "^1.0.8",
-        "tailwind-config-viewer": "^1.6.2",
         "tailwindcss": "^2.2.7",
         "ts-node": "^10.1.0",
         "typescript": "^4.3.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "lint:fix": "npm run lint:ts:fix",
         "lint:ts": "eslint 'src/**/*.{ts,tsx}'",
         "lint:ts:fix": "eslint --fix 'src/**/*.{ts,tsx}'",
-        "tailwind:view-config": "tailwind-config-viewer -o",
         "test": "npm run build:css && cypress run-ct",
         "test:browser": "npm run build:css && cypress open-ct",
         "test:file": "npm run build:css && cypress run-ct --spec",


### PR DESCRIPTION
We can just use `npx tailwind-config-viewer` instead of installing it