### PR TITLE
feat(Form Control): Add Form Control Styles

### DIFF
--- a/src/compositions/FormControl/FormControl.stories.tsx
+++ b/src/compositions/FormControl/FormControl.stories.tsx
@@ -7,12 +7,13 @@ import { TextInput } from "@elements/TextInput/TextInput";
 import { Meta, Story } from "@storybook/react";
 import generateRandomId from "@utilities/generateRandomId";
 import React, { useState } from "react";
-import { FormControl, FormControlDirection, FormControlProps, HelperPosition, HelperTextStyle } from "./FormControl";
+import { FormControl, FormControlDirection, FormControlProps, HelperPosition, FormControlStyle } from "./FormControl";
 
 export default {
     title: "Compositions/Form Control",
     component: FormControl,
     args: {
+        style: FormControlStyle.Primary,
         disabled: false,
         direction: FormControlDirection.Vertical,
         label: {
@@ -25,7 +26,6 @@ export default {
         helper: {
             text: "Helper Text (before/after) and variant (Primary/Success/Danger)",
             position: HelperPosition.After,
-            style: HelperTextStyle.Primary,
         },
         children: "",
     },
@@ -36,6 +36,10 @@ export default {
         },
         children: {
             table: { disable: true },
+        },
+        style: {
+            options: Object.values(FormControlStyle),
+            control: "radio",
         },
     },
 } as Meta<FormControlProps>;

--- a/src/compositions/FormControl/FormControl.tsx
+++ b/src/compositions/FormControl/FormControl.tsx
@@ -1,9 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { InputLabel, InputLabelProps } from "@elements/InputLabel/InputLabel";
+import { Validation } from "@elements/TextInput/TextInput";
 import React, { cloneElement, FC, isValidElement, PropsWithChildren, ReactNode } from "react";
 
-export enum HelperTextStyle {
+export enum FormControlStyle {
     Primary = "Primary",
     Positive = "Positive",
     Danger = "Danger",
@@ -11,9 +12,15 @@ export enum HelperTextStyle {
 
 type HelperTextProps = {
     text: string;
+    style: FormControlStyle;
     disabled?: boolean;
-    style?: HelperTextStyle;
     fullWidth?: boolean;
+};
+
+const inputValidation: Record<FormControlStyle, Validation> = {
+    [FormControlStyle.Primary]: Validation.Default,
+    [FormControlStyle.Positive]: Validation.Success,
+    [FormControlStyle.Danger]: Validation.Error,
 };
 
 const HelperText: FC<HelperTextProps> = ({ text, disabled, style, fullWidth = false }) => (
@@ -22,9 +29,9 @@ const HelperText: FC<HelperTextProps> = ({ text, disabled, style, fullWidth = fa
         className={`tw-text-s tw-font-sans ${fullWidth ? "tw-w-full" : ""} ${
             disabled
                 ? "tw-text-black-40"
-                : style === HelperTextStyle.Danger
+                : style === FormControlStyle.Danger
                 ? "tw-text-red-60"
-                : style === HelperTextStyle.Positive
+                : style === FormControlStyle.Positive
                 ? "tw-text-green-60"
                 : "tw-text-black-80"
         }`}
@@ -48,7 +55,8 @@ export type FormControlProps = PropsWithChildren<{
     disabled?: boolean;
     label?: Omit<InputLabelProps, "disabled">;
     extra?: ReactNode;
-    helper?: Omit<HelperTextProps, "disabled"> & { position?: HelperPosition };
+    helper?: Omit<HelperTextProps, "disabled" | "style"> & { position?: HelperPosition };
+    style?: FormControlStyle;
 }>;
 
 export const FormControl: FC<FormControlProps> = ({
@@ -58,6 +66,7 @@ export const FormControl: FC<FormControlProps> = ({
     helper,
     disabled,
     direction = FormControlDirection.Vertical,
+    style = FormControlStyle.Primary,
 }) => {
     const isHelperBefore = helper?.position === HelperPosition.Before;
 
@@ -87,21 +96,23 @@ export const FormControl: FC<FormControlProps> = ({
             )}
             {helper?.text && isHelperBefore && (
                 <HelperText
+                    style={style}
                     fullWidth={direction === FormControlDirection.Vertical}
                     text={helper.text}
                     disabled={disabled}
-                    style={helper.style}
                 />
             )}
             <div className={direction === FormControlDirection.Vertical ? "tw-w-full" : ""}>
-                {isValidElement(children) ? cloneElement(children, { id: label?.htmlFor, disabled }) : children}
+                {isValidElement(children)
+                    ? cloneElement(children, { id: label?.htmlFor, disabled, validation: inputValidation[style] })
+                    : children}
             </div>
             {helper?.text && !isHelperBefore && (
                 <HelperText
                     fullWidth={direction === FormControlDirection.Vertical}
                     text={helper.text}
                     disabled={disabled}
-                    style={helper.style}
+                    style={style}
                 />
             )}
         </div>

--- a/src/elements/TextInput/TextInput.tsx
+++ b/src/elements/TextInput/TextInput.tsx
@@ -26,7 +26,7 @@ const validationStyle: Record<Validation, string> = {
     [Validation.Default]: "tw-border-black-20",
     [Validation.Loading]: "tw-border-black-10",
     [Validation.Success]: "tw-border-green-50",
-    [Validation.Error]: "tw-border-red-50",
+    [Validation.Error]: "tw-border-red-60",
 };
 
 const Spinner = (): ReactElement => (


### PR DESCRIPTION
This PR removes the `HelperTextStyle` and adds a `FormControlStyle` which allows us to have the text input field and the helper text to be styled (for example when the input validation failed)

Here is an example with `FormControlStyle.Danger`:

![image](https://user-images.githubusercontent.com/15727229/133580563-cc7d6c0c-8624-4f70-a968-3c2e4f1f8700.png)
