### PR TITLE
fix(Color Picker): Update Input Values When Changing Color With Drag and Drop

### DIFF
--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -8,7 +8,7 @@ import { TextInput } from "@elements/TextInput/TextInput";
 import { toColor } from "@utilities/colors";
 import { debounce } from "@utilities/debounce";
 import { merge } from "@utilities/merge";
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, FormEvent, useEffect, useState } from "react";
 import { ColorPickerProps } from "./ColorPicker";
 
 const find = (haystack?: string, needle = "") =>
@@ -45,9 +45,13 @@ export const BrandColorPicker: FC<ColorPickerProps> = ({ palettes: defaultPalett
             <div className="tw-flex tw-gap-3">
                 <div className="tw-flex-1">
                     <TextInput
+                        value=""
                         decorator={<IconSearch />}
                         placeholder="Search"
-                        onInput={debounce((value) => setQuery(value), 200)}
+                        onChange={debounce(
+                            (event: FormEvent<HTMLInputElement>) => setQuery(event.currentTarget.value),
+                            200,
+                        )}
                     />
                 </div>
                 <div className="tw-w-[72px]">

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -8,7 +8,7 @@ import { TextInput } from "@elements/TextInput/TextInput";
 import { toColor } from "@utilities/colors";
 import { debounce } from "@utilities/debounce";
 import { merge } from "@utilities/merge";
-import React, { FC, FormEvent, useEffect, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { ColorPickerProps } from "./ColorPicker";
 
 const find = (haystack?: string, needle = "") =>
@@ -48,10 +48,7 @@ export const BrandColorPicker: FC<ColorPickerProps> = ({ palettes: defaultPalett
                         value=""
                         decorator={<IconSearch />}
                         placeholder="Search"
-                        onChange={debounce(
-                            (event: FormEvent<HTMLInputElement>) => setQuery(event.currentTarget.value),
-                            200,
-                        )}
+                        onChange={debounce((value) => setQuery(value), 200)}
                     />
                 </div>
                 <div className="tw-w-[72px]">

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -126,7 +126,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                             max={100}
                             size={3}
                             type={TextInputType.Number}
-                            defaultValue={`${rgb.a * 100}`}
+                            defaultValue={`${Math.round(rgb.a * 100)}`}
                             decorator="%"
                             onInput={(a) =>
                                 onSelect(toColor(currentColor, { rgba: { a: parseInt(a || "0", 10) / 100 } }))

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -138,7 +138,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                             max={100}
                             size={3}
                             type={TextInputType.Number}
-                            value={Math.round(rgb.a * 100)}
+                            value={`${Math.round(rgb.a * 100)}`}
                             decorator="%"
                             onChange={(event) => {
                                 const a = parseInt(event.currentTarget.value || "0", 10) / 100;

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -86,10 +86,13 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                     >
                         {colorFormat === ColorFormat.Hex ? (
                             <TextInput
-                                defaultValue={hex.substring(1)}
+                                value={hex.substring(1)}
                                 decorator="#"
                                 size={6}
-                                onInput={(hex) => isValidHex(hex) && onSelect(toColor(currentColor, { hex }))}
+                                onChange={(event) => {
+                                    const hex = event.currentTarget.value;
+                                    isValidHex(hex) && onSelect(toColor(currentColor, { hex }));
+                                }}
                             />
                         ) : (
                             <>
@@ -97,25 +100,34 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                                     min={0}
                                     max={255}
                                     type={TextInputType.Number}
-                                    defaultValue={`${rgb.r}`}
+                                    value={rgb.r}
                                     decorator="R"
-                                    onInput={(r) => onSelect(toColor(currentColor, { rgba: { r } }))}
+                                    onChange={(event) => {
+                                        const r = event.currentTarget.value;
+                                        onSelect(toColor(currentColor, { rgba: { r } }));
+                                    }}
                                 />
                                 <TextInput
                                     min={0}
                                     max={255}
                                     type={TextInputType.Number}
-                                    defaultValue={`${rgb.g}`}
+                                    value={rgb.g}
                                     decorator="G"
-                                    onInput={(g) => onSelect(toColor(currentColor, { rgba: { g } }))}
+                                    onChange={(event) => {
+                                        const g = event.currentTarget.value;
+                                        onSelect(toColor(currentColor, { rgba: { g } }));
+                                    }}
                                 />
                                 <TextInput
                                     min={0}
                                     max={255}
                                     type={TextInputType.Number}
-                                    defaultValue={`${rgb.b}`}
+                                    value={rgb.b}
                                     decorator="B"
-                                    onInput={(b) => onSelect(toColor(currentColor, { rgba: { b } }))}
+                                    onChange={(event) => {
+                                        const b = event.currentTarget.value;
+                                        onSelect(toColor(currentColor, { rgba: { b } }));
+                                    }}
                                 />
                             </>
                         )}
@@ -126,11 +138,12 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                             max={100}
                             size={3}
                             type={TextInputType.Number}
-                            defaultValue={`${Math.round(rgb.a * 100)}`}
+                            value={Math.round(rgb.a * 100)}
                             decorator="%"
-                            onInput={(a) =>
-                                onSelect(toColor(currentColor, { rgba: { a: parseInt(a || "0", 10) / 100 } }))
-                            }
+                            onChange={(event) => {
+                                const a = parseInt(event.currentTarget.value || "0", 10) / 100;
+                                onSelect(toColor(currentColor, { rgba: { a } }));
+                            }}
                         />
                     </div>
                 </div>

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -89,10 +89,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                                 value={hex.substring(1)}
                                 decorator="#"
                                 size={6}
-                                onChange={(event) => {
-                                    const hex = event.currentTarget.value;
-                                    isValidHex(hex) && onSelect(toColor(currentColor, { hex }));
-                                }}
+                                onChange={(hex) => isValidHex(hex) && onSelect(toColor(currentColor, { hex }))}
                             />
                         ) : (
                             <>
@@ -102,10 +99,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                                     type={TextInputType.Number}
                                     value={rgb.r}
                                     decorator="R"
-                                    onChange={(event) => {
-                                        const r = event.currentTarget.value;
-                                        onSelect(toColor(currentColor, { rgba: { r } }));
-                                    }}
+                                    onChange={(r) => onSelect(toColor(currentColor, { rgba: { r } }))}
                                 />
                                 <TextInput
                                     min={0}
@@ -113,10 +107,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                                     type={TextInputType.Number}
                                     value={rgb.g}
                                     decorator="G"
-                                    onChange={(event) => {
-                                        const g = event.currentTarget.value;
-                                        onSelect(toColor(currentColor, { rgba: { g } }));
-                                    }}
+                                    onChange={(g) => onSelect(toColor(currentColor, { rgba: { g } }))}
                                 />
                                 <TextInput
                                     min={0}
@@ -124,10 +115,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                                     type={TextInputType.Number}
                                     value={rgb.b}
                                     decorator="B"
-                                    onChange={(event) => {
-                                        const b = event.currentTarget.value;
-                                        onSelect(toColor(currentColor, { rgba: { b } }));
-                                    }}
+                                    onChange={(b) => onSelect(toColor(currentColor, { rgba: { b } }))}
                                 />
                             </>
                         )}
@@ -140,8 +128,8 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({ curre
                             type={TextInputType.Number}
                             value={`${Math.round(rgb.a * 100)}`}
                             decorator="%"
-                            onChange={(event) => {
-                                const a = parseInt(event.currentTarget.value || "0", 10) / 100;
+                            onChange={(value) => {
+                                const a = parseInt(value || "0", 10) / 100;
                                 onSelect(toColor(currentColor, { rgba: { a } }));
                             }}
                         />

--- a/src/components/Flyout/Flyout.spec.tsx
+++ b/src/components/Flyout/Flyout.spec.tsx
@@ -22,7 +22,7 @@ describe("Flyout Component", () => {
                 badges={[{ children: "Badge 1" }, { children: "Badge 2" }]}
                 onClose={onCloseStub}
             >
-                <TextInput value="" placeholder="placeholder" />
+                <TextInput placeholder="placeholder" />
             </Flyout>,
         );
 

--- a/src/components/Flyout/Flyout.spec.tsx
+++ b/src/components/Flyout/Flyout.spec.tsx
@@ -22,7 +22,7 @@ describe("Flyout Component", () => {
                 badges={[{ children: "Badge 1" }, { children: "Badge 2" }]}
                 onClose={onCloseStub}
             >
-                <TextInput placeholder="placeholder" />
+                <TextInput value="" placeholder="placeholder" />
             </Flyout>,
         );
 

--- a/src/elements/TextInput/TextInput.spec.tsx
+++ b/src/elements/TextInput/TextInput.spec.tsx
@@ -82,11 +82,11 @@ describe("Text Input component", () => {
         cy.get(CLEAR_ICON_ID).should("not.exist");
     });
 
-    it("calls the onInput event", () => {
-        const onInputStub = cy.stub().as("onInputStub");
-        mount(<StatefulInput onChange={onInputStub} />);
+    it("calls the onChange event", () => {
+        const onChangeStub = cy.stub().as("onChangeStub");
+        mount(<TextInput value="" onChange={onChangeStub} />);
         cy.get(TEXT_INPUT_ID).type(INPUT_TEXT);
-        cy.get("@onInputStub").should("to.have.always.been.callCount", INPUT_TEXT.length);
+        cy.get("@onChangeStub").should("to.have.always.been.callCount", INPUT_TEXT.length);
     });
 
     it("calls the onBlur event", () => {

--- a/src/elements/TextInput/TextInput.spec.tsx
+++ b/src/elements/TextInput/TextInput.spec.tsx
@@ -1,7 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { mount } from "@cypress/react";
-import React from "react";
+import React, { FC, useEffect, useState } from "react";
+import { TextInputProps } from "src";
 import { TextInput, TextInputType } from "./TextInput";
 
 export const TEXT_INPUT_ID = "[data-test-id=text-input]";
@@ -14,9 +15,27 @@ const CLEAR_ICON_ID = "[data-test-id=clear-icon]";
 const DECORATOR_ID = "[data-test-id=decorator]";
 const VISIBILITY_ICON_ID = "[data-test-id=visibility-icon]";
 
+const StatefulInput: FC<TextInputProps> = (props) => {
+    const [input, setInput] = useState<string>("");
+
+    useEffect(() => {
+        setInput(props.value || "");
+    }, [props.value]);
+
+    return (
+        <TextInput
+            {...props}
+            value={input}
+            onChange={(event) => {
+                setInput(event.currentTarget.value);
+            }}
+        />
+    );
+};
+
 describe("Text Input component", () => {
     it("renders the text input", () => {
-        mount(<TextInput />);
+        mount(<StatefulInput />);
         cy.get(TEXT_INPUT_ID).should("have.attr", "type", "text");
         cy.get(TEXT_INPUT_ID).should("not.have.attr", "placeholder");
         cy.get(TEXT_INPUT_ID).find(CLEAR_ICON_ID).should("have.length", 0);
@@ -24,12 +43,12 @@ describe("Text Input component", () => {
     });
 
     it("set and get the value", () => {
-        mount(<TextInput value={INPUT_TEXT} />);
+        mount(<StatefulInput value={INPUT_TEXT} />);
         cy.get(TEXT_INPUT_ID).should("have.value", INPUT_TEXT);
     });
 
     it("uses passwords correctly", () => {
-        mount(<TextInput type={TextInputType.Password} />);
+        mount(<StatefulInput type={TextInputType.Password} />);
         cy.get(TEXT_INPUT_ID).type(PASSWORD);
         cy.get(TEXT_INPUT_ID).should("have.attr", "type", "password");
         cy.get(TEXT_INPUT_ID).should("have.value", PASSWORD);
@@ -40,31 +59,31 @@ describe("Text Input component", () => {
     });
 
     it("renders the placeholder", () => {
-        mount(<TextInput placeholder={PLACEHOLDER} />);
+        mount(<StatefulInput placeholder={PLACEHOLDER} />);
         cy.get("input").should("have.attr", "placeholder").and("eq", PLACEHOLDER);
     });
 
     it("renders the decorator", () => {
-        mount(<TextInput decorator={DECORATOR} />);
+        mount(<StatefulInput decorator={DECORATOR} />);
         cy.get(DECORATOR_ID).should("be.visible").contains(DECORATOR_TEXT);
     });
 
     it("hides the clear icon when there is no text in the field", () => {
-        mount(<TextInput clearable />);
+        mount(<StatefulInput clearable />);
         cy.get(CLEAR_ICON_ID).should("not.exist");
         cy.get(TEXT_INPUT_ID).type(INPUT_TEXT).should("have.value", INPUT_TEXT);
         cy.get(CLEAR_ICON_ID).should("exist");
     });
 
     it("clears the field when clicked on the clear icon", () => {
-        mount(<TextInput clearable />);
+        mount(<StatefulInput clearable />);
         cy.get(TEXT_INPUT_ID).type(INPUT_TEXT).should("have.value", INPUT_TEXT);
         cy.get(CLEAR_ICON_ID).click();
         cy.get(TEXT_INPUT_ID).should("have.value", "").should("not.have.value", INPUT_TEXT);
     });
 
     it("remove the clean icon when pressing it", () => {
-        mount(<TextInput clearable />);
+        mount(<StatefulInput clearable />);
         cy.get(TEXT_INPUT_ID).type(INPUT_TEXT).should("have.value", INPUT_TEXT);
         cy.get(CLEAR_ICON_ID).should("exist");
         cy.get(CLEAR_ICON_ID).click();
@@ -73,21 +92,21 @@ describe("Text Input component", () => {
 
     it("calls the onInput event", () => {
         const onInputStub = cy.stub().as("onInputStub");
-        mount(<TextInput onChange={onInputStub} />);
+        mount(<StatefulInput onChange={onInputStub} />);
         cy.get(TEXT_INPUT_ID).type(INPUT_TEXT);
         cy.get("@onInputStub").should("to.have.always.been.callCount", INPUT_TEXT.length);
     });
 
     it("calls the onBlur event", () => {
         const onBlurStub = cy.stub().as("onBlurStub");
-        mount(<TextInput onBlur={onBlurStub} />);
+        mount(<StatefulInput onBlur={onBlurStub} />);
         cy.get(TEXT_INPUT_ID).type(INPUT_TEXT).blur();
         cy.get("@onBlurStub").should("be.calledOnce");
     });
 
     it("calls the onClear event", () => {
         const onClearStub = cy.stub().as("onClearStub");
-        mount(<TextInput onClear={onClearStub} clearable />);
+        mount(<StatefulInput onClear={onClearStub} clearable />);
         cy.get(TEXT_INPUT_ID).type(INPUT_TEXT);
         cy.get(CLEAR_ICON_ID).click();
         cy.get(TEXT_INPUT_ID).should("have.value", "");
@@ -95,22 +114,22 @@ describe("Text Input component", () => {
     });
 
     it("has the required attribute", () => {
-        mount(<TextInput required={true} />);
+        mount(<StatefulInput required={true} />);
         cy.get(TEXT_INPUT_ID).should("have.attr", "required");
     });
 
     it("does not have the required attribute", () => {
-        mount(<TextInput required={false} />);
+        mount(<StatefulInput required={false} />);
         cy.get(TEXT_INPUT_ID).should("not.have.attr", "required");
     });
 
     it("has the disabled attribute", () => {
-        mount(<TextInput disabled={true} />);
+        mount(<StatefulInput disabled={true} />);
         cy.get(TEXT_INPUT_ID).should("have.attr", "disabled");
     });
 
     it("does not have the disabled attribute", () => {
-        mount(<TextInput disabled={false} />);
+        mount(<StatefulInput disabled={false} />);
         cy.get(TEXT_INPUT_ID).should("not.have.attr", "disabled");
     });
 });

--- a/src/elements/TextInput/TextInput.spec.tsx
+++ b/src/elements/TextInput/TextInput.spec.tsx
@@ -22,15 +22,7 @@ const StatefulInput: FC<TextInputProps> = (props) => {
         setInput(props.value || "");
     }, [props.value]);
 
-    return (
-        <TextInput
-            {...props}
-            value={input}
-            onChange={(event) => {
-                setInput(event.currentTarget.value);
-            }}
-        />
-    );
+    return <TextInput {...props} value={input} onChange={setInput} />;
 };
 
 describe("Text Input component", () => {

--- a/src/elements/TextInput/TextInput.spec.tsx
+++ b/src/elements/TextInput/TextInput.spec.tsx
@@ -24,7 +24,7 @@ describe("Text Input component", () => {
     });
 
     it("set and get the value", () => {
-        mount(<TextInput defaultValue={INPUT_TEXT} />);
+        mount(<TextInput value={INPUT_TEXT} />);
         cy.get(TEXT_INPUT_ID).should("have.value", INPUT_TEXT);
     });
 
@@ -73,7 +73,7 @@ describe("Text Input component", () => {
 
     it("calls the onInput event", () => {
         const onInputStub = cy.stub().as("onInputStub");
-        mount(<TextInput onInput={onInputStub} />);
+        mount(<TextInput onChange={onInputStub} />);
         cy.get(TEXT_INPUT_ID).type(INPUT_TEXT);
         cy.get("@onInputStub").should("to.have.always.been.callCount", INPUT_TEXT.length);
     });

--- a/src/elements/TextInput/TextInput.stories.tsx
+++ b/src/elements/TextInput/TextInput.stories.tsx
@@ -38,13 +38,13 @@ const TextInputTemplate: Story<TextInputProps> = (args) => <TextInput {...args} 
 export const Text = TextInputTemplate.bind({});
 
 Text.argTypes = {
-    defaultValue: { table: { disable: false }, type: "string" },
+    value: { table: { disable: false }, type: "string" },
 };
 
 export const Prefilled = TextInputTemplate.bind({});
 
 Prefilled.args = {
-    defaultValue: "Value text",
+    value: "Value text",
 };
 
 export const WithPlaceholder = TextInputTemplate.bind({});
@@ -56,7 +56,7 @@ WithPlaceholder.args = {
 export const WithIconDecorator = TextInputTemplate.bind({});
 
 WithIconDecorator.args = {
-    defaultValue: "Value text",
+    value: "Value text",
     decorator: <IconIcons size={IconSize.Size16} />,
 };
 

--- a/src/elements/TextInput/TextInput.stories.tsx
+++ b/src/elements/TextInput/TextInput.stories.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import IconIcons from "@elements/Icon/Generated/IconIcons";
 import { IconSize } from "@elements/Icon/IconSize";
 import { Meta, Story } from "@storybook/react";
@@ -23,7 +23,7 @@ export default {
             type: "select",
         },
         placeholder: { type: "string" },
-        defaultValue: { table: { disable: true } },
+        value: { table: { disable: true } },
         obfuscated: { table: { disable: true } },
         type: { table: { disable: true } },
         decorator: { table: { disable: true } },
@@ -33,7 +33,12 @@ export default {
     },
 } as Meta<TextInputProps>;
 
-const TextInputTemplate: Story<TextInputProps> = (args) => <TextInput {...args} />;
+const TextInputTemplate: Story<TextInputProps> = (args) => {
+    const [input, setInput] = useState("");
+    useEffect(() => setInput(`${args.value || ""}`), [args.value]);
+
+    return <TextInput {...args} value={input} onChange={(event) => setInput(`${event.currentTarget.value}`)} />;
+};
 
 export const Text = TextInputTemplate.bind({});
 
@@ -73,7 +78,7 @@ const PasswordArgTypes = {
 
 const PasswordArgs = {
     type: TextInputType.Password,
-    defaultValue: "Secret",
+    value: "Secret",
 };
 
 export const Password = TextInputTemplate.bind({});
@@ -112,7 +117,7 @@ PasswordVisible.args = {
 export const TypeNumber = TextInputTemplate.bind({});
 
 TypeNumber.argTypes = {
-    defaultValue: { table: { disable: false }, type: "number" },
+    value: { table: { disable: false }, type: "number" },
 };
 
 TypeNumber.args = {

--- a/src/elements/TextInput/TextInput.stories.tsx
+++ b/src/elements/TextInput/TextInput.stories.tsx
@@ -37,7 +37,7 @@ const TextInputTemplate: Story<TextInputProps> = (args) => {
     const [input, setInput] = useState("");
     useEffect(() => setInput(`${args.value || ""}`), [args.value]);
 
-    return <TextInput {...args} value={input} onChange={(event) => setInput(`${event.currentTarget.value}`)} />;
+    return <TextInput {...args} value={input} onChange={setInput} />;
 };
 
 export const Text = TextInputTemplate.bind({});

--- a/src/elements/TextInput/TextInput.tsx
+++ b/src/elements/TextInput/TextInput.tsx
@@ -52,8 +52,8 @@ type TextInputBaseProps = {
     validation?: Validation;
     value?: string;
     onChange?: (value: string) => void;
-    onEnterPressed?: (e: KeyboardEvent<HTMLInputElement>) => void;
-    onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+    onEnterPressed?: (event: KeyboardEvent<HTMLInputElement>) => void;
+    onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
     onClear?: () => void;
     size?: number;
 };

--- a/src/elements/TextInput/TextInput.tsx
+++ b/src/elements/TextInput/TextInput.tsx
@@ -60,6 +60,7 @@ type TextInputBaseProps = {
     required?: boolean;
     disabled?: boolean;
     validation?: Validation;
+    value?: string;
     onChange?: (e: FormEvent<HTMLInputElement>) => void;
     onEnterPressed?: (e: KeyboardEvent<HTMLInputElement>) => void;
     onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
@@ -71,19 +72,16 @@ export type TextInputProps =
     | ({
           type?: TextInputType.Text;
           obfuscated?: false;
-          value?: string;
       } & TextInputBaseProps)
     | ({
           type?: TextInputType.Number;
           obfuscated?: false;
           min?: number;
           max?: number;
-          value?: number;
       } & TextInputBaseProps)
     | ({
           type: TextInputType.Password;
           obfuscated?: boolean;
-          value?: string;
       } & TextInputBaseProps);
 
 export const TextInput: FC<TextInputProps> = ({

--- a/src/elements/TextInput/TextInput.tsx
+++ b/src/elements/TextInput/TextInput.tsx
@@ -7,17 +7,7 @@ import { useMemoizedId } from "@hooks/useMemoizedId";
 import { useFocusRing } from "@react-aria/focus";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
 import { merge } from "@utilities/merge";
-import React, {
-    FC,
-    FocusEvent,
-    FormEvent,
-    KeyboardEvent,
-    ReactElement,
-    ReactNode,
-    useEffect,
-    useRef,
-    useState,
-} from "react";
+import React, { FC, FocusEvent, KeyboardEvent, ReactElement, ReactNode, useEffect, useRef, useState } from "react";
 
 export enum TextInputType {
     Text = "text",
@@ -61,7 +51,7 @@ type TextInputBaseProps = {
     disabled?: boolean;
     validation?: Validation;
     value?: string;
-    onChange?: (e: FormEvent<HTMLInputElement>) => void;
+    onChange?: (value: string) => void;
     onEnterPressed?: (e: KeyboardEvent<HTMLInputElement>) => void;
     onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
     onClear?: () => void;
@@ -155,7 +145,7 @@ export const TextInput: FC<TextInputProps> = ({
                         ? "tw-text-black-40 tw-placeholder-black-30 dark:tw-text-black-30 dark:tw-placeholder-black-40 tw-cursor-not-allowed"
                         : "tw-text-black tw-placeholder-black-60 dark:tw-text-white",
                 ])}
-                onChange={onChange}
+                onChange={(event) => onChange && onChange(event.currentTarget.value)}
                 onBlur={onBlur}
                 onKeyDown={onKeyDown}
                 placeholder={placeholder}
@@ -180,8 +170,9 @@ export const TextInput: FC<TextInputProps> = ({
                     ])}
                     onClick={() => {
                         inputElement.current?.focus();
-                        // setInputContent("");
                         inputElement.current?.setAttribute("value", "");
+
+                        onChange && onChange("");
                         onClear && onClear();
                     }}
                     data-test-id="clear-icon"

--- a/src/elements/TextInput/TextInput.tsx
+++ b/src/elements/TextInput/TextInput.tsx
@@ -100,6 +100,12 @@ export const TextInput: FC<TextInputProps> = ({
 
     const [inputContent, setInputContent] = useState<string>(defaultValue || "");
 
+    useEffect(() => {
+        if (defaultValue) {
+            setInputContent(defaultValue);
+        }
+    }, [defaultValue]);
+
     const onTextInput = (event: FormEvent<HTMLInputElement>) => {
         const value = (event.target as HTMLInputElement).value;
         setInputContent(value);


### PR DESCRIPTION
⚠️ **BREAKING CHANGES INCOMING** 

The `TextInput` was an uncontrolled component, which means that it handled the input value itself. This way we could only pass the `defaultValue`. When this one was updated, the changes weren't reflected in the input itself.

In our experience with React (and according to the docs) in most cases controlled form components are preferred over uncontrolled. Therefore this change does exactly this.

More info:

- Uncontrolled Components: https://reactjs.org/docs/uncontrolled-components.html
- Controlled Components: https://reactjs.org/docs/forms.html#controlled-components
