### PR TITLE
Fix: show checkbox tooltip only if it's given

### DIFF
--- a/src/elements/Checkbox/Checkbox.tsx
+++ b/src/elements/Checkbox/Checkbox.tsx
@@ -93,7 +93,7 @@ export const Checkbox: FC<CheckboxProps> = (props) => {
                     <InputLabel
                         disabled={disabled}
                         htmlFor={id}
-                        tooltip={{ content: tooltip }}
+                        tooltip={tooltip ? { content: tooltip } : undefined}
                         required={required}
                         bold={isCheckedOrMixed(state)}
                     >


### PR DESCRIPTION
Currently the tooltip shows up with empty content for all checkboxes:

![image](https://user-images.githubusercontent.com/15727229/135039132-78f07964-231e-4ec6-8ca8-f2b6913bcf03.png)

With this change we're only showing the tooltip if it's given:

![image](https://user-images.githubusercontent.com/15727229/135039207-c22d7911-ff82-4080-bcf0-04cf25a8cecc.png)
