### PR TITLE
Fix/tag component

### DIFF
--- a/src/elements/Tag/Tag.spec.tsx
+++ b/src/elements/Tag/Tag.spec.tsx
@@ -62,4 +62,12 @@ describe("Tag Component", () => {
         cy.get(TAG_ID).click();
         cy.get("@onClickStub").should("be.calledOnce");
     });
+
+    it("should be able to gain focus on keyboard tab press", () => {
+        mount(<Tag type={TagType.SelectedWithFocus} label={TAG_LABEL} />);
+
+        cy.window().focus();
+        cy.get("body").realPress("Tab");
+        cy.get(TAG_ID).should("be.focused");
+    });
 });

--- a/src/elements/Tag/Tag.tsx
+++ b/src/elements/Tag/Tag.tsx
@@ -20,7 +20,7 @@ export const tagStyles: Record<TagType, string> = {
     [TagType.SelectedWithFocus]:
         "tw-bg-violet-60 dark:tw-bg-violet-50 hover:tw-bg-violet-70 dark:hover:tw-bg-violet-60 tw-border-violet-60 dark:tw-border-violet-50 hover:tw-border-violet-70 dark:hover:tw-border-violet-60 tw-text-white",
     [TagType.PreviouslySelected]:
-        "tw-bg-white dark:tw-bg-black-100 hover:tw-bg-black-0 dark:hover:tw-bg-black-superdark tw-text-violet-60 dark:tw-text-violet-50 hover:text-violet-70 dark:hover:tw-text-violet-60",
+        "tw-bg-white dark:tw-bg-black-100 hover:tw-bg-black-0 dark:hover:tw-bg-black-superdark tw-text-violet-60 dark:tw-text-violet-50 hover:tw-text-violet-70 dark:hover:tw-text-violet-60",
 };
 
 export type TagProps = {

--- a/src/elements/Tag/Tag.tsx
+++ b/src/elements/Tag/Tag.tsx
@@ -36,7 +36,7 @@ export const Tag: FC<TagProps> = ({ type, label, onClick }) => {
         <button
             data-test-id="tag"
             className={merge([
-                "tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-px-2.5 tw-py-1",
+                "tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group tw-px-2.5 tw-py-1",
                 tagStyles[type],
                 isClickable ? "tw-cursor-pointer" : "tw-cursor-default",
             ])}
@@ -44,7 +44,10 @@ export const Tag: FC<TagProps> = ({ type, label, onClick }) => {
         >
             {label}
             {isClickable && (
-                <span data-test-id="tag-reject-icon" className="tw-ml-1">
+                <span
+                    data-test-id="tag-reject-icon"
+                    className="tw-opacity-80 group-hover:tw-opacity-100 tw-transition-opacity tw-ml-1"
+                >
                     <IconReject size={IconSize.Size12} />
                 </span>
             )}

--- a/src/elements/Tag/Tag.tsx
+++ b/src/elements/Tag/Tag.tsx
@@ -36,15 +36,18 @@ export const Tag: FC<TagProps> = ({ type, label, onClick }) => {
 
     const isClickable = (type === TagType.Selected || type === TagType.SelectedWithFocus) && onClick;
 
-    const buttonClasses = merge([
-        "tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group tw-px-2.5 tw-py-1",
-        tagStyles[type],
-        isClickable ? "tw-cursor-pointer" : "tw-cursor-default",
-        isFocusVisible && FOCUS_STYLE,
-    ]);
-
     return (
-        <button data-test-id="tag" className={buttonClasses} onClick={onClick} {...focusProps}>
+        <button
+            data-test-id="tag"
+            className={merge([
+                "tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group tw-px-2.5 tw-py-1",
+                tagStyles[type],
+                isClickable ? "tw-cursor-pointer" : "tw-cursor-default",
+                isFocusVisible && FOCUS_STYLE,
+            ])}
+            onClick={onClick}
+            {...focusProps}
+        >
             {label}
             {isClickable && (
                 <span

--- a/src/elements/Tag/Tag.tsx
+++ b/src/elements/Tag/Tag.tsx
@@ -2,7 +2,9 @@
 
 import React, { FC } from "react";
 import { merge } from "@utilities/merge";
+import { useFocusRing } from "@react-aria/focus";
 import { IconSize } from "@elements/Icon/IconSize";
+import { FOCUS_STYLE } from "@utilities/focusStyle";
 import IconReject from "@elements/Icon/Generated/IconReject";
 
 export enum TagType {
@@ -30,18 +32,19 @@ export type TagProps = {
 };
 
 export const Tag: FC<TagProps> = ({ type, label, onClick }) => {
+    const { isFocusVisible, focusProps } = useFocusRing();
+
     const isClickable = (type === TagType.Selected || type === TagType.SelectedWithFocus) && onClick;
 
+    const buttonClasses = merge([
+        "tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group tw-px-2.5 tw-py-1",
+        tagStyles[type],
+        isClickable ? "tw-cursor-pointer" : "tw-cursor-default",
+        isFocusVisible && FOCUS_STYLE,
+    ]);
+
     return (
-        <button
-            data-test-id="tag"
-            className={merge([
-                "tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group tw-px-2.5 tw-py-1",
-                tagStyles[type],
-                isClickable ? "tw-cursor-pointer" : "tw-cursor-default",
-            ])}
-            onClick={onClick}
-        >
+        <button data-test-id="tag" className={buttonClasses} onClick={onClick} {...focusProps}>
             {label}
             {isClickable && (
                 <span


### PR DESCRIPTION
This PR contains the following:

- Fix the text and border color on hover for the `PreviouslySelected` type
- Fix the opacity of the reject icon
- Allow the tag to be focused using a keyboard along with the correct styles
- Add a test related to focusing the component using a keyboard
- Extract out the button element classes to a variable to improve template readability