### PR TITLE
fix: make grid default view for BrandColorPicker

### DIFF
--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -1,10 +1,10 @@
 import { Slider } from "@components/Slider/Slider";
+import { TextInput } from "@components/TextInput/TextInput";
 import IconCheck from "@foundation/Icon/Generated/IconCheck";
 import IconImageGrid2 from "@foundation/Icon/Generated/IconImageGrid2";
 import IconListBullets from "@foundation/Icon/Generated/IconListBullets";
 import IconSearch from "@foundation/Icon/Generated/IconSearch";
 import { IconSize } from "@foundation/Icon/IconSize";
-import { TextInput } from "@components/TextInput/TextInput";
 import { toColor } from "@utilities/colors";
 import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useState } from "react";
@@ -20,8 +20,8 @@ enum BrandColorView {
 
 export const BrandColorPicker: FC<ColorPickerProps> = ({ palettes: defaultPalettes = [], currentColor, onSelect }) => {
     const views = [
-        { id: BrandColorView.List, icon: <IconListBullets />, ariaLabel: "List" },
         { id: BrandColorView.Grid, icon: <IconImageGrid2 />, ariaLabel: "Grid" },
+        { id: BrandColorView.List, icon: <IconListBullets />, ariaLabel: "List" },
     ];
     const [view, setView] = useState(views[0].id);
     const [query, setQuery] = useState("");

--- a/src/components/ColorPicker/ColorPicker.spec.tsx
+++ b/src/components/ColorPicker/ColorPicker.spec.tsx
@@ -1,12 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { DROPDOWN_TRIGGER_ID } from "@components/Dropdown/Dropdown.spec";
+import { MENU_ITEM_ID } from "@components/MenuItem/MenuItem.spec";
 import { ICON_ITEM_ID, TEXT_ITEM_ID } from "@components/Slider/Slider.spec";
 import { mount } from "@cypress/react";
-import { MENU_ITEM_ID } from "@components/MenuItem/MenuItem.spec";
 import { EXAMPLE_PALETTES } from "@utilities/colors";
-import { Color } from "../../types/colors";
 import React, { FC, useState } from "react";
+import { Color } from "../../types/colors";
 import { ColorPicker, Palette } from "./ColorPicker";
 
 export const BRAND_COLOR_ID = "[data-test-id=brand-color]";
@@ -54,9 +54,9 @@ describe("ColorPicker Component", () => {
     it("should change palette display", () => {
         mount(<Component palettes={EXAMPLE_PALETTES} />);
 
-        cy.get(BRAND_COLOR_ID).parent("ul").should("have.class", "tw-flex-col");
-        cy.get(ICON_ITEM_ID).last().click();
         cy.get(BRAND_COLOR_ID).parent("ul").should("not.have.class", "tw-flex-col");
+        cy.get(ICON_ITEM_ID).last().click();
+        cy.get(BRAND_COLOR_ID).parent("ul").should("have.class", "tw-flex-col");
     });
 
     it("should display correct search results", () => {


### PR DESCRIPTION
Concerns this ticket: https://app.clickup.com/t/nq8zf6