### PR TITLE
feat: Add TooltipIcon Component

### DIFF
--- a/src/components/Checkbox/Checkbox.spec.tsx
+++ b/src/components/Checkbox/Checkbox.spec.tsx
@@ -8,7 +8,7 @@ const CHECKBOX_LABEL = "Checkbox label";
 export const CHECKBOX_ID = "[data-test-id=checkbox]";
 const TOOLTIP_ID = "[data-test-id=tooltip]";
 export const CHECKBOX_INPUT_ID = "[data-test-id=checkbox-input]";
-const INPUT_LABEL_TOOLTIP_ICON_ID = "[data-test-id=input-label-tooltip-icon]";
+const TOOLTIP_ICON_TRIGGER_ID = "[data-test-id=tooltip-icon-trigger]";
 
 const CheckboxComponent: FC<Omit<CheckboxProps, "value">> = (props) => {
     const [checked, setChecked] = useState(props.state);
@@ -54,7 +54,7 @@ describe("Checkbox component", () => {
     it("renders with a tooltip", () => {
         mount(<CheckboxComponent label={CHECKBOX_LABEL} tooltip={{ content: "Checkbox tooltip" }} />);
 
-        cy.get(INPUT_LABEL_TOOLTIP_ICON_ID).should("exist");
+        cy.get(TOOLTIP_ICON_TRIGGER_ID).should("exist");
     });
 
     it("renders as disabled", () => {
@@ -80,7 +80,7 @@ describe("Checkbox component", () => {
         cy.window().focus();
         cy.get("body").realPress("Tab");
         cy.get("body").realPress("Tab");
-        cy.get(INPUT_LABEL_TOOLTIP_ICON_ID).should("be.focused");
+        cy.get(TOOLTIP_ICON_TRIGGER_ID).should("be.focused");
         cy.get(TOOLTIP_ID).should("contain", "Checkbox tooltip");
     });
 });

--- a/src/components/InputLabel/InputLabel.spec.tsx
+++ b/src/components/InputLabel/InputLabel.spec.tsx
@@ -9,7 +9,7 @@ const LABEL_TOOLTIP = "This is a fancy tooltip.";
 
 const INPUT_LABEL_ID = "[data-test-id=input-label]";
 const INPUT_LABEL_CONTAINER_ID = "[data-test-id=input-label-container]";
-const INPUT_LABEL_TOOLTIP_ICON_ID = "[data-test-id=input-label-tooltip-icon]";
+const TOOLTIP_ICON_TRIGGER_ID = "[data-test-id=tooltip-icon-trigger]";
 const TOOLTIP_ID = "[data-test-id=tooltip]";
 const INPUT_LABEL_REQUIRED_ID = "[data-test-id=input-label-required]";
 
@@ -37,7 +37,7 @@ describe("InputLabel Component", () => {
             </InputLabel>,
         );
 
-        cy.get(INPUT_LABEL_TOOLTIP_ICON_ID).realHover({ position: "top" });
+        cy.get(TOOLTIP_ICON_TRIGGER_ID).realHover({ position: "top" });
         cy.get(INPUT_LABEL_CONTAINER_ID).find(TOOLTIP_ID).should("exist");
     });
 });

--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -1,16 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Tooltip, TooltipProps } from "@components/Tooltip/Tooltip";
-import { TooltipArrow } from "@components/Tooltip/TooltipArrow";
-import IconQuestion from "@foundation/Icon/Generated/IconQuestion";
+import { TooltipProps } from "@components/Tooltip/Tooltip";
+import { TooltipIcon } from "@components/TooltipIcon/TooltipIcon";
 import { IconSize } from "@foundation/Icon/IconSize";
-import { useFocusVisible, useHover } from "@react-aria/interactions";
-import { useTooltipTrigger } from "@react-aria/tooltip";
-import { useTooltipTriggerState } from "@react-stately/tooltip";
-import { FOCUS_STYLE } from "@utilities/focusStyle";
 import { merge } from "@utilities/merge";
-import React, { FC, PropsWithChildren, useRef, useState } from "react";
-import { usePopper } from "react-popper";
+import React, { FC, PropsWithChildren } from "react";
 
 export type InputLabelProps = PropsWithChildren<{
     htmlFor: string;
@@ -20,10 +14,6 @@ export type InputLabelProps = PropsWithChildren<{
     bold?: boolean;
 }>;
 
-const TOOLTIP_DISTANCE = 15;
-const TOOLTIP_SKIDDING = 0;
-const TOOLTIP_PADDING = 15;
-
 export const InputLabel: FC<InputLabelProps> = ({
     children,
     htmlFor,
@@ -32,28 +22,6 @@ export const InputLabel: FC<InputLabelProps> = ({
     tooltip,
     bold,
 }) => {
-    const tooltipElement = useRef<HTMLDivElement | null>(null);
-    const [tooltipArrowElement, setTooltipArrowElement] = useState<HTMLElement | null>(null);
-    const tooltipTriggerElement = useRef<HTMLButtonElement | null>(null);
-    const state = useTooltipTriggerState();
-    const { triggerProps, tooltipProps } = useTooltipTrigger({}, state, tooltipTriggerElement);
-    const { isOpen } = state;
-
-    const { isFocusVisible } = useFocusVisible();
-
-    const { styles, attributes } = usePopper(tooltipTriggerElement.current, tooltipElement.current, {
-        placement: "auto",
-        modifiers: [
-            { name: "offset", options: { offset: [TOOLTIP_SKIDDING, TOOLTIP_DISTANCE] } },
-            { name: "arrow", options: { element: tooltipArrowElement, padding: TOOLTIP_PADDING } },
-        ],
-    });
-
-    const { hoverProps } = useHover({
-        onHoverStart: () => state.open(),
-        onHoverEnd: () => state.close(),
-    });
-
     return (
         <div
             className={merge([
@@ -88,39 +56,7 @@ export const InputLabel: FC<InputLabelProps> = ({
                     *
                 </span>
             )}
-            {tooltip && (
-                <>
-                    <div {...hoverProps}>
-                        <button
-                            data-test-id="input-label-tooltip-icon"
-                            ref={tooltipTriggerElement}
-                            className={merge([
-                                "tw-inline-flex tw-justify-center tw-items-center tw-text-black-60 hover:tw-text-black-60 dark:tw-text-black-40 dark:hover:tw-text-white tw-cursor-default tw-outline-none tw-rounded-full",
-                                isOpen && isFocusVisible && FOCUS_STYLE,
-                            ])}
-                            {...triggerProps}
-                        >
-                            <IconQuestion size={IconSize.Size16} />
-                        </button>
-                        {isOpen && (
-                            <Tooltip
-                                {...tooltip}
-                                popperAttributes={attributes.popper}
-                                ref={tooltipElement}
-                                style={styles.popper}
-                                tooltipAriaProps={tooltipProps}
-                            >
-                                <TooltipArrow
-                                    ref={setTooltipArrowElement}
-                                    style={styles.arrow}
-                                    placement={attributes.popper?.["data-popper-placement"]}
-                                    headerColor={tooltip.brightHeader}
-                                />
-                            </Tooltip>
-                        )}
-                    </div>
-                </>
-            )}
+            {tooltip && <TooltipIcon tooltip={tooltip} iconSize={IconSize.Size16} />}
         </div>
     );
 };

--- a/src/components/TooltipIcon/TooltipIcon.spec.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.spec.tsx
@@ -1,16 +1,34 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-/* import { mount } from "@cypress/react";
 import React from "react";
+import { mount } from "@cypress/react";
 import { TooltipIcon } from "./TooltipIcon";
+import { IconSize } from "@foundation/Icon/IconSize";
 
-const TOOLTIP_COMPONENT = <Tooltip content="Cupcake ipsum dolor sit amet ice cream." />;
+const TOOLTIP_PROPS = {
+    content: "Lorem ipsum dolor sit amet.",
+};
 const TOOLTIP_ICON_ID = "[data-test-id=tooltip-icon]";
+const TOOLTIP_ICON_TRIGGER_ID = "[data-test-id=tooltip-icon-trigger]";
+const TOOLTIP_ID = "[data-test-id=tooltip]";
 
 describe("TooltipIcon Component", () => {
-    it("should render a tooltip icon", () => {
-        mount(<TooltipIcon content={TOOLTIP_COMPONENT} />);
+    it("should render an icon with default size", () => {
+        mount(<TooltipIcon tooltip={TOOLTIP_PROPS} />);
 
-        cy.get(TOOLTIP_ICON_ID).should("contain", TOOLTIP_COMPONENT);
+        cy.get(TOOLTIP_ICON_ID).find(TOOLTIP_ICON_TRIGGER_ID).children().should("have.class", "tw-h-4");
     });
-}); */
+
+    it("should render an icon with custom size", () => {
+        mount(<TooltipIcon tooltip={TOOLTIP_PROPS} iconSize={IconSize.Size20} />);
+
+        cy.get(TOOLTIP_ICON_ID).find(TOOLTIP_ICON_TRIGGER_ID).children().should("have.class", "tw-h-5");
+    });
+
+    it("should render a tooltip when the icon is hovered", () => {
+        mount(<TooltipIcon tooltip={TOOLTIP_PROPS} />);
+
+        cy.get(TOOLTIP_ICON_TRIGGER_ID).realHover({ position: "top" });
+        cy.get(TOOLTIP_ICON_ID).find(TOOLTIP_ID).should("exist");
+    });
+});

--- a/src/components/TooltipIcon/TooltipIcon.spec.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.spec.tsx
@@ -28,7 +28,7 @@ describe("TooltipIcon Component", () => {
     it("should render a tooltip when the icon is hovered", () => {
         mount(<TooltipIcon tooltip={TOOLTIP_PROPS} />);
 
-        cy.get(TOOLTIP_ICON_ID).realHover({ position: "top" });
+        cy.get(TOOLTIP_ICON_TRIGGER_ID).realHover({ position: "top" });
         cy.get(TOOLTIP_ICON_ID).find(TOOLTIP_ID).should("exist");
     });
 });

--- a/src/components/TooltipIcon/TooltipIcon.spec.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.spec.tsx
@@ -1,16 +1,16 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { mount } from "@cypress/react";
+/* import { mount } from "@cypress/react";
 import React from "react";
 import { TooltipIcon } from "./TooltipIcon";
 
-const TOOLTIP_ICON_TEXT = "This is a tooltip icon";
+const TOOLTIP_COMPONENT = <Tooltip content="Cupcake ipsum dolor sit amet ice cream." />;
 const TOOLTIP_ICON_ID = "[data-test-id=tooltip-icon]";
 
 describe("TooltipIcon Component", () => {
     it("should render a tooltip icon", () => {
-        mount(<TooltipIcon content={TOOLTIP_ICON_TEXT} />);
+        mount(<TooltipIcon content={TOOLTIP_COMPONENT} />);
 
-        cy.get(TOOLTIP_ICON_ID).should("contain", TOOLTIP_ICON_TEXT);
+        cy.get(TOOLTIP_ICON_ID).should("contain", TOOLTIP_COMPONENT);
     });
-});
+}); */

--- a/src/components/TooltipIcon/TooltipIcon.spec.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.spec.tsx
@@ -1,0 +1,16 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { mount } from "@cypress/react";
+import React from "react";
+import { TooltipIcon } from "./TooltipIcon";
+
+const TOOLTIP_ICON_TEXT = "This is a tooltip icon";
+const TOOLTIP_ICON_ID = "[data-test-id=tooltip-icon]";
+
+describe("TooltipIcon Component", () => {
+    it("should render a tooltip icon", () => {
+        mount(<TooltipIcon content={TOOLTIP_ICON_TEXT} />);
+
+        cy.get(TOOLTIP_ICON_ID).should("contain", TOOLTIP_ICON_TEXT);
+    });
+});

--- a/src/components/TooltipIcon/TooltipIcon.spec.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.spec.tsx
@@ -28,6 +28,7 @@ describe("TooltipIcon Component", () => {
     it("should render a tooltip when the icon is hovered", () => {
         mount(<TooltipIcon tooltip={TOOLTIP_PROPS} />);
 
+        cy.get("body").realClick();
         cy.get(TOOLTIP_ICON_TRIGGER_ID).realHover({ position: "top" });
         cy.get(TOOLTIP_ICON_ID).find(TOOLTIP_ID).should("exist");
     });

--- a/src/components/TooltipIcon/TooltipIcon.spec.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.spec.tsx
@@ -28,7 +28,7 @@ describe("TooltipIcon Component", () => {
     it("should render a tooltip when the icon is hovered", () => {
         mount(<TooltipIcon tooltip={TOOLTIP_PROPS} />);
 
-        cy.get(TOOLTIP_ICON_TRIGGER_ID).realHover({ position: "top" });
+        cy.get(TOOLTIP_ICON_ID).realHover({ position: "top" });
         cy.get(TOOLTIP_ICON_ID).find(TOOLTIP_ID).should("exist");
     });
 });

--- a/src/components/TooltipIcon/TooltipIcon.stories.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.stories.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
 import { TooltipIcon, TooltipIconProps } from "./TooltipIcon";
-import { Tooltip } from "@components/Tooltip/Tooltip";
 
 export default {
     title: "Components/TooltipIcon",
@@ -20,5 +19,7 @@ export const WithDefaultContent = TooltipIconTemplate.bind({});
 
 export const WithCustomContent = TooltipIconTemplate.bind({});
 WithCustomContent.args = {
-    tooltip: <Tooltip content="Cupcake ipsum dolor sit amet ice cream." />,
+    tooltip: {
+        content: "Lorem ipsum dolor sit amet.",
+    },
 };

--- a/src/components/TooltipIcon/TooltipIcon.stories.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.stories.tsx
@@ -1,0 +1,24 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+import { TooltipIcon, TooltipIconProps } from "./TooltipIcon";
+import { Tooltip } from "@components/Tooltip/Tooltip";
+
+export default {
+    title: "Components/TooltipIcon",
+    component: TooltipIcon,
+    argTypes: {},
+    args: {},
+} as Meta<TooltipIconProps>;
+
+const TooltipIconTemplate: Story<TooltipIconProps> = (args: TooltipIconProps) => {
+    return <TooltipIcon {...args} />;
+};
+
+export const WithDefaultContent = TooltipIconTemplate.bind({});
+
+export const WithCustomContent = TooltipIconTemplate.bind({});
+WithCustomContent.args = {
+    tooltip: <Tooltip content="Cupcake ipsum dolor sit amet ice cream." />,
+};

--- a/src/components/TooltipIcon/TooltipIcon.stories.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.stories.tsx
@@ -9,7 +9,11 @@ export default {
     title: "Components/TooltipIcon",
     component: TooltipIcon,
     argTypes: {},
-    args: {},
+    args: {
+        tooltip: {
+            content: "Lorem ipsum dolor sit amet.",
+        },
+    },
 } as Meta<TooltipIconProps>;
 
 const TooltipIconTemplate: Story<TooltipIconProps> = (args: TooltipIconProps) => {
@@ -17,16 +21,8 @@ const TooltipIconTemplate: Story<TooltipIconProps> = (args: TooltipIconProps) =>
 };
 
 export const WithDefaultIconSize = TooltipIconTemplate.bind({});
-WithDefaultIconSize.args = {
-    tooltip: {
-        content: "Lorem ipsum dolor sit amet.",
-    },
-};
 
 export const WithCustomIconSize = TooltipIconTemplate.bind({});
 WithCustomIconSize.args = {
-    tooltip: {
-        content: "Lorem ipsum dolor sit amet.",
-    },
     iconSize: IconSize.Size20,
 };

--- a/src/components/TooltipIcon/TooltipIcon.stories.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.stories.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
 import { TooltipIcon, TooltipIconProps } from "./TooltipIcon";
+import { IconSize } from "@foundation/Icon/IconSize";
 
 export default {
     title: "Components/TooltipIcon",
@@ -15,11 +16,17 @@ const TooltipIconTemplate: Story<TooltipIconProps> = (args: TooltipIconProps) =>
     return <TooltipIcon {...args} />;
 };
 
-export const WithDefaultContent = TooltipIconTemplate.bind({});
-
-export const WithCustomContent = TooltipIconTemplate.bind({});
-WithCustomContent.args = {
+export const WithDefaultIconSize = TooltipIconTemplate.bind({});
+WithDefaultIconSize.args = {
     tooltip: {
         content: "Lorem ipsum dolor sit amet.",
     },
+};
+
+export const WithCustomIconSize = TooltipIconTemplate.bind({});
+WithCustomIconSize.args = {
+    tooltip: {
+        content: "Lorem ipsum dolor sit amet.",
+    },
+    iconSize: IconSize.Size20,
 };

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -44,37 +44,35 @@ export const TooltipIcon: FC<TooltipIconProps> = ({ tooltip, iconSize = IconSize
     return (
         <div data-test-id="tooltip-icon">
             {tooltip && (
-                <>
-                    <div {...hoverProps}>
-                        <button
-                            data-test-id="input-label-tooltip-icon"
-                            ref={tooltipTriggerElement}
-                            className={merge([
-                                "tw-inline-flex tw-justify-center tw-items-center tw-text-black-60 hover:tw-text-black-60 dark:tw-text-black-40 dark:hover:tw-text-white tw-cursor-default tw-outline-none tw-rounded-full",
-                                isOpen && isFocusVisible && FOCUS_STYLE,
-                            ])}
-                            {...triggerProps}
+                <div {...hoverProps}>
+                    <button
+                        data-test-id="input-label-tooltip-icon"
+                        ref={tooltipTriggerElement}
+                        className={merge([
+                            "tw-inline-flex tw-justify-center tw-items-center tw-text-black-60 hover:tw-text-black-60 dark:tw-text-black-40 dark:hover:tw-text-white tw-cursor-default tw-outline-none tw-rounded-full",
+                            isOpen && isFocusVisible && FOCUS_STYLE,
+                        ])}
+                        {...triggerProps}
+                    >
+                        <IconQuestion size={iconSize} />
+                    </button>
+                    {isOpen && (
+                        <Tooltip
+                            {...tooltip}
+                            popperAttributes={attributes.popper}
+                            ref={tooltipElement}
+                            style={styles.popper}
+                            tooltipAriaProps={tooltipProps}
                         >
-                            <IconQuestion size={iconSize} />
-                        </button>
-                        {isOpen && (
-                            <Tooltip
-                                {...tooltip}
-                                popperAttributes={attributes.popper}
-                                ref={tooltipElement}
-                                style={styles.popper}
-                                tooltipAriaProps={tooltipProps}
-                            >
-                                <TooltipArrow
-                                    ref={setTooltipArrowElement}
-                                    style={styles.arrow}
-                                    placement={attributes.popper?.["data-popper-placement"]}
-                                    headerColor={tooltip.brightHeader}
-                                />
-                            </Tooltip>
-                        )}
-                    </div>
-                </>
+                            <TooltipArrow
+                                ref={setTooltipArrowElement}
+                                style={styles.arrow}
+                                placement={attributes.popper?.["data-popper-placement"]}
+                                headerColor={tooltip.brightHeader}
+                            />
+                        </Tooltip>
+                    )}
+                </div>
             )}
         </div>
     );

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -1,0 +1,21 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import React, { FC, ReactElement } from "react";
+import IconQuestion from "@foundation/Icon/Generated/IconQuestion";
+import { IconSize } from "@foundation/Icon/IconSize";
+import { TooltipProps } from "@components/Tooltip/Tooltip";
+
+export type TooltipIconProps = {
+    tooltip: ReactElement<TooltipProps>;
+};
+
+export const TooltipIcon: FC<TooltipIconProps> = ({ tooltip }: TooltipIconProps) => {
+    return (
+        <div data-test-id="tooltip-icon">
+            <span className="tw-text-black-80">
+                <IconQuestion size={IconSize.Size20} />
+                {tooltip}
+            </span>
+        </div>
+    );
+};

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -1,23 +1,80 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC } from "react";
-import { Tooltip, TooltipProps } from "@components/Tooltip/Tooltip";
+import React, { FC, useRef, useState } from "react";
+import { usePopper } from "react-popper";
+import { useFocusVisible, useHover } from "@react-aria/interactions";
+import { useTooltipTrigger } from "@react-aria/tooltip";
+import { useTooltipTriggerState } from "@react-stately/tooltip";
 import IconQuestion from "@foundation/Icon/Generated/IconQuestion";
 import { IconSize } from "@foundation/Icon/IconSize";
+import { Tooltip, TooltipProps } from "@components/Tooltip/Tooltip";
+import { TooltipArrow } from "@components/Tooltip/TooltipArrow";
+import { FOCUS_STYLE } from "@utilities/focusStyle";
+import { merge } from "@utilities/merge";
 
 export type TooltipIconProps = {
     tooltip?: Omit<TooltipProps, "tooltipAriaProps">;
     iconSize?: IconSize;
 };
 
+const TOOLTIP_DISTANCE = 15;
+const TOOLTIP_SKIDDING = 0;
+const TOOLTIP_PADDING = 15;
+
 export const TooltipIcon: FC<TooltipIconProps> = ({ tooltip, iconSize = IconSize.Size16 }: TooltipIconProps) => {
+    const [tooltipArrowElement, setTooltipArrowElement] = useState<HTMLElement | null>(null);
+    const tooltipTriggerElement = useRef<HTMLButtonElement | null>(null);
+    const tooltipElement = useRef<HTMLDivElement | null>(null);
+    const state = useTooltipTriggerState();
+    const { triggerProps, tooltipProps } = useTooltipTrigger({}, state, tooltipTriggerElement);
+    const { isOpen } = state;
+    const { isFocusVisible } = useFocusVisible();
+    const { styles, attributes } = usePopper(tooltipTriggerElement.current, tooltipElement.current, {
+        placement: "auto",
+        modifiers: [
+            { name: "offset", options: { offset: [TOOLTIP_SKIDDING, TOOLTIP_DISTANCE] } },
+            { name: "arrow", options: { element: tooltipArrowElement, padding: TOOLTIP_PADDING } },
+        ],
+    });
+    const { hoverProps } = useHover({
+        onHoverStart: () => state.open(),
+        onHoverEnd: () => state.close(),
+    });
+
     return (
         <div data-test-id="tooltip-icon">
             {tooltip && (
-        <>
-            <IconQuestion size={iconSize} />
-            <Tooltip {...tooltip} />
-        </>
+                <>
+                    <div {...hoverProps}>
+                        <button
+                            data-test-id="input-label-tooltip-icon"
+                            ref={tooltipTriggerElement}
+                            className={merge([
+                                "tw-inline-flex tw-justify-center tw-items-center tw-text-black-60 hover:tw-text-black-60 dark:tw-text-black-40 dark:hover:tw-text-white tw-cursor-default tw-outline-none tw-rounded-full",
+                                isOpen && isFocusVisible && FOCUS_STYLE,
+                            ])}
+                            {...triggerProps}
+                        >
+                            <IconQuestion size={iconSize} />
+                        </button>
+                        {isOpen && (
+                            <Tooltip
+                                {...tooltip}
+                                popperAttributes={attributes.popper}
+                                ref={tooltipElement}
+                                style={styles.popper}
+                                tooltipAriaProps={tooltipProps}
+                            >
+                                <TooltipArrow
+                                    ref={setTooltipArrowElement}
+                                    style={styles.arrow}
+                                    placement={attributes.popper?.["data-popper-placement"]}
+                                    headerColor={tooltip.brightHeader}
+                                />
+                            </Tooltip>
+                        )}
+                    </div>
+                </>
             )}
         </div>
     );

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -1,29 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC, ReactElement } from "react";
-import IconQuestion from "@foundation/Icon/Generated/IconQuestion";
-import { IconSize } from "@foundation/Icon/IconSize";
-import { TooltipProps } from "@components/Tooltip/Tooltip";
-import { useHover } from "@react-aria/interactions";
+import React, { FC } from "react";
+import { Tooltip, TooltipProps } from "@components/Tooltip/Tooltip";
 
 export type TooltipIconProps = {
-    tooltip: ReactElement<TooltipProps>;
+    tooltip?: Omit<TooltipProps, "tooltipAriaProps">;
 };
 
 export const TooltipIcon: FC<TooltipIconProps> = ({ tooltip }: TooltipIconProps) => {
-    const { hoverProps, isHovered } = useHover({
-        onHoverStart: () => console.log("hover start"),
-        onHoverEnd: () => console.log("hover end"),
-    });
-
-    console.log("hoverProps:", hoverProps, isHovered);
-
-    return (
-        <div data-test-id="tooltip-icon" {...hoverProps}>
-            <span className="tw-text-black-80">
-                <IconQuestion size={IconSize.Size20} />
-                {tooltip}
-            </span>
-        </div>
-    );
+    return <div data-test-id="tooltip-icon">{tooltip && <Tooltip {...tooltip} />}</div>;
 };

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -46,7 +46,7 @@ export const TooltipIcon: FC<TooltipIconProps> = ({ tooltip, iconSize = IconSize
             {tooltip && (
                 <div {...hoverProps}>
                     <button
-                        data-test-id="input-label-tooltip-icon"
+                        data-test-id="tooltip-icon-trigger"
                         ref={tooltipTriggerElement}
                         className={merge([
                             "tw-inline-flex tw-justify-center tw-items-center tw-text-black-60 hover:tw-text-black-60 dark:tw-text-black-40 dark:hover:tw-text-white tw-cursor-default tw-outline-none tw-rounded-full",

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -4,14 +4,22 @@ import React, { FC, ReactElement } from "react";
 import IconQuestion from "@foundation/Icon/Generated/IconQuestion";
 import { IconSize } from "@foundation/Icon/IconSize";
 import { TooltipProps } from "@components/Tooltip/Tooltip";
+import { useHover } from "@react-aria/interactions";
 
 export type TooltipIconProps = {
     tooltip: ReactElement<TooltipProps>;
 };
 
 export const TooltipIcon: FC<TooltipIconProps> = ({ tooltip }: TooltipIconProps) => {
+    const { hoverProps, isHovered } = useHover({
+        onHoverStart: () => console.log('hover start'),
+        onHoverEnd: () => console.log('hover end'),
+    });
+
+    console.log('hoverProps:', hoverProps, isHovered);
+    
     return (
-        <div data-test-id="tooltip-icon">
+        <div data-test-id="tooltip-icon" {...hoverProps}>
             <span className="tw-text-black-80">
                 <IconQuestion size={IconSize.Size20} />
                 {tooltip}

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -12,12 +12,12 @@ export type TooltipIconProps = {
 
 export const TooltipIcon: FC<TooltipIconProps> = ({ tooltip }: TooltipIconProps) => {
     const { hoverProps, isHovered } = useHover({
-        onHoverStart: () => console.log('hover start'),
-        onHoverEnd: () => console.log('hover end'),
+        onHoverStart: () => console.log("hover start"),
+        onHoverEnd: () => console.log("hover end"),
     });
 
-    console.log('hoverProps:', hoverProps, isHovered);
-    
+    console.log("hoverProps:", hoverProps, isHovered);
+
     return (
         <div data-test-id="tooltip-icon" {...hoverProps}>
             <span className="tw-text-black-80">

--- a/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/src/components/TooltipIcon/TooltipIcon.tsx
@@ -2,11 +2,23 @@
 
 import React, { FC } from "react";
 import { Tooltip, TooltipProps } from "@components/Tooltip/Tooltip";
+import IconQuestion from "@foundation/Icon/Generated/IconQuestion";
+import { IconSize } from "@foundation/Icon/IconSize";
 
 export type TooltipIconProps = {
     tooltip?: Omit<TooltipProps, "tooltipAriaProps">;
+    iconSize?: IconSize;
 };
 
-export const TooltipIcon: FC<TooltipIconProps> = ({ tooltip }: TooltipIconProps) => {
-    return <div data-test-id="tooltip-icon">{tooltip && <Tooltip {...tooltip} />}</div>;
+export const TooltipIcon: FC<TooltipIconProps> = ({ tooltip, iconSize = IconSize.Size16 }: TooltipIconProps) => {
+    return (
+        <div data-test-id="tooltip-icon">
+            {tooltip && (
+        <>
+            <IconQuestion size={iconSize} />
+            <Tooltip {...tooltip} />
+        </>
+            )}
+        </div>
+    );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export * from "./components/TextInput/TextInput";
 export * from "./components/Tooltip/BrightHeader";
 export * from "./components/Tooltip/Tooltip";
 export * from "./components/Tooltip/TooltipArrow";
+export * from "./components/TooltipIcon/TooltipIcon";
 export * from "./components/Tree/Node";
 export * from "./components/Tree/Tree";
 export * from "./components/Trigger/Trigger";


### PR DESCRIPTION
**Changes:**
- Extracting the logic of tooltip and the icon that triggers it out of `InputLabel` and into a separate `TooltipIcon` component
- Using the newly created `TooltipIcon` component inside `InputLabel` in place of the previous code
- Allowing the new component to set the size of the icon
- Updating tests

Storybook: http://localhost:6006/?path=/story/components-tooltipicon--with-default-icon-size
