### PR TITLE
Feature - Add persisted icon to dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -5,12 +5,14 @@ import { mount } from "@cypress/react";
 import { MENU_ITEM_ACTIVE_ID, MENU_ITEM_ID, MENU_ITEM_TITLE_ID } from "@components/MenuItem/MenuItem.spec";
 import { MenuItemContentSize } from "@components/MenuItem/MenuItemContent";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
-import React, { FC, useState } from "react";
+import React, { FC, ReactElement, useState } from "react";
 import { Dropdown } from "./Dropdown";
+import IconIcons from "@foundation/Icon/Generated/IconIcons";
 
 export const DROPDOWN_TRIGGER_ID = "[data-test-id=dropdown-trigger]";
 const DROPDOWN_CLEAR_BUTTON_ID = "[data-test-id=dropdown-clear-button]";
 const MENU_ITEM_LIST_ID = "[data-test-id=menu-item-list]";
+const MENU_ITEM_DECORATOR_ID = "[data-test-id=menu-item-decorator]";
 const TRIGGER_ID = "[data-test-id=trigger]";
 
 const ITEMS = [
@@ -44,9 +46,17 @@ type Props = {
     initialActiveId?: string | number;
     clearable?: boolean;
     disabled?: boolean;
+    persistedIcon?: ReactElement;
 };
 
-const Component: FC<Props> = ({ menuBlocks, placeholder, initialActiveId, clearable = false, disabled = false }) => {
+const Component: FC<Props> = ({
+    menuBlocks,
+    placeholder,
+    initialActiveId,
+    clearable = false,
+    disabled = false,
+    persistedIcon,
+}) => {
     const [activeItemId, setActiveItemId] = useState(initialActiveId);
     return (
         <Dropdown
@@ -56,6 +66,7 @@ const Component: FC<Props> = ({ menuBlocks, placeholder, initialActiveId, cleara
             placeholder={placeholder}
             clearable={clearable}
             disabled={disabled}
+            persistedIcon={persistedIcon}
         />
     );
 };
@@ -118,5 +129,11 @@ describe("Dropdown Component", () => {
         FOCUS_STYLE.split(" ").forEach((style) => {
             cy.get(TRIGGER_ID).should("not.have.class", style);
         });
+    });
+
+    it.only("should display persisted icon if provided", () => {
+        mount(<Component menuBlocks={ITEMS} persistedIcon={<IconIcons />} />);
+
+        cy.get(`${MENU_ITEM_DECORATOR_ID} > svg`).invoke("attr", "name").should("eq", "IconIcons");
     });
 });

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -131,6 +131,12 @@ describe("Dropdown Component", () => {
         });
     });
 
+    it("should not display persisted icon if omitted", () => {
+        mount(<Component menuBlocks={ITEMS} />);
+
+        cy.get(`${MENU_ITEM_DECORATOR_ID} > svg`).should("not.exist");
+    });
+
     it("should display persisted icon if provided", () => {
         mount(<Component menuBlocks={ITEMS} persistedIcon={<IconIcons />} />);
 

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -46,7 +46,7 @@ type Props = {
     initialActiveId?: string | number;
     clearable?: boolean;
     disabled?: boolean;
-    persistedIcon?: ReactElement;
+    decorator?: ReactElement;
 };
 
 const Component: FC<Props> = ({
@@ -55,7 +55,7 @@ const Component: FC<Props> = ({
     initialActiveId,
     clearable = false,
     disabled = false,
-    persistedIcon,
+    decorator,
 }) => {
     const [activeItemId, setActiveItemId] = useState(initialActiveId);
     return (
@@ -66,7 +66,7 @@ const Component: FC<Props> = ({
             placeholder={placeholder}
             clearable={clearable}
             disabled={disabled}
-            persistedIcon={persistedIcon}
+            decorator={decorator}
         />
     );
 };
@@ -138,7 +138,7 @@ describe("Dropdown Component", () => {
     });
 
     it("should display persisted icon if provided", () => {
-        mount(<Component menuBlocks={ITEMS} persistedIcon={<IconIcons />} />);
+        mount(<Component menuBlocks={ITEMS} decorator={<IconIcons />} />);
 
         cy.get(`${MENU_ITEM_DECORATOR_ID} > svg`).invoke("attr", "name").should("eq", "IconIcons");
     });

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -131,7 +131,7 @@ describe("Dropdown Component", () => {
         });
     });
 
-    it.only("should display persisted icon if provided", () => {
+    it("should display persisted icon if provided", () => {
         mount(<Component menuBlocks={ITEMS} persistedIcon={<IconIcons />} />);
 
         cy.get(`${MENU_ITEM_DECORATOR_ID} > svg`).invoke("attr", "name").should("eq", "IconIcons");

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -13,7 +13,7 @@ import { mergeProps } from "@react-aria/utils";
 import { useSelectState } from "@react-stately/select";
 import { merge } from "@utilities/merge";
 import { AnimatePresence, motion } from "framer-motion";
-import React, { FC, useRef } from "react";
+import React, { FC, ReactElement, useRef } from "react";
 
 export enum DropdownSize {
     Small = "Small",
@@ -30,6 +30,7 @@ export type DropdownProps = {
     disabled?: boolean;
     clearable?: boolean;
     ariaLabel?: string;
+    persistedIcon?: ReactElement;
 };
 
 const getActiveItem = (blocks: MenuBlock[], activeId?: string | number) =>
@@ -48,6 +49,7 @@ export const Dropdown: FC<DropdownProps> = ({
     disabled = false,
     clearable = false,
     ariaLabel = "Dropdown",
+    persistedIcon,
 }) => {
     const activeItem = getActiveItem(menuBlocks, activeItemId);
     const props = mapToAriaProps(ariaLabel, menuBlocks);
@@ -104,7 +106,7 @@ export const Dropdown: FC<DropdownProps> = ({
                     <MenuItemContent
                         ariaProps={valueProps}
                         title={activeItem?.title || placeholder}
-                        decorator={activeItem?.decorator}
+                        decorator={persistedIcon ?? activeItem?.decorator}
                         size={size === DropdownSize.Small ? MenuItemContentSize.Small : MenuItemContentSize.Large}
                     />
                 </button>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -30,7 +30,7 @@ export type DropdownProps = {
     disabled?: boolean;
     clearable?: boolean;
     ariaLabel?: string;
-    persistedIcon?: ReactElement;
+    decorator?: ReactElement;
 };
 
 const getActiveItem = (blocks: MenuBlock[], activeId?: string | number) =>
@@ -49,7 +49,7 @@ export const Dropdown: FC<DropdownProps> = ({
     disabled = false,
     clearable = false,
     ariaLabel = "Dropdown",
-    persistedIcon,
+    decorator,
 }) => {
     const activeItem = getActiveItem(menuBlocks, activeItemId);
     const props = mapToAriaProps(ariaLabel, menuBlocks);
@@ -106,7 +106,7 @@ export const Dropdown: FC<DropdownProps> = ({
                     <MenuItemContent
                         ariaProps={valueProps}
                         title={activeItem?.title || placeholder}
-                        decorator={persistedIcon ?? activeItem?.decorator}
+                        decorator={decorator ?? activeItem?.decorator}
                         size={size === DropdownSize.Small ? MenuItemContentSize.Small : MenuItemContentSize.Large}
                     />
                 </button>


### PR DESCRIPTION
Allows the parent to pass the persistedIcon prop to the dropdown to display an icon at the beginning of the text input that doesn't get affected by the currently selected item.