### PR TITLE
Fix unclickable areas inside dropdown

### DIFF
--- a/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
@@ -33,7 +33,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
                 {...focusProps}
                 id={useMemoizedId(id)}
                 className={merge([
-                    "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none tw-py-1 tw-px-3",
+                    "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none tw-py-2 tw-px-3 tw-min-h-[34px]",
                     !currentColor && "tw-text-black-60",
                     disabled && "tw-text-black-40",
                 ])}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -69,7 +69,7 @@ export const Dropdown: FC<DropdownProps> = ({
     );
 
     return (
-        <div className="tw-relative tw-w-full tw-font-sans tw-text-s ">
+        <div className="tw-relative tw-w-full tw-font-sans tw-text-s">
             <Trigger
                 disabled={disabled}
                 buttonProps={buttonProps}
@@ -96,7 +96,7 @@ export const Dropdown: FC<DropdownProps> = ({
                     data-test-id="dropdown-trigger"
                     className={merge([
                         "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none",
-                        size === DropdownSize.Small ? "tw-py-1 tw-px-3" : "tw-p-5 tw-min-h-[60px]",
+                        size === DropdownSize.Small ? "tw-py-2 tw-px-3 tw-min-h-[34px]" : "tw-p-5 tw-min-h-[60px]",
                         !activeItem && "tw-text-black-60",
                         disabled && "tw-text-black-40",
                     ])}

--- a/src/components/MenuItem/MenuItemContent.tsx
+++ b/src/components/MenuItem/MenuItemContent.tsx
@@ -32,7 +32,7 @@ export const MenuItemContent: FC<MenuItemContentProps> = ({
     <div
         {...ariaProps}
         data-test-id="menu-item-content"
-        className={merge(["tw-flex tw-box-border tw-items-center tw-font-sans tw-text-s"])}
+        className="tw-flex tw-box-border tw-items-center tw-font-sans tw-text-s"
     >
         {decorator && (
             <span

--- a/src/components/MenuItem/MenuItemContent.tsx
+++ b/src/components/MenuItem/MenuItemContent.tsx
@@ -32,19 +32,24 @@ export const MenuItemContent: FC<MenuItemContentProps> = ({
     <div
         {...ariaProps}
         data-test-id="menu-item-content"
-        className={merge([
-            "tw-flex tw-box-border tw-items-center tw-font-sans tw-text-s",
-            size === MenuItemContentSize.Large ? "tw-gap-3" : "tw-gap-2",
-        ])}
+        className={merge(["tw-flex tw-box-border tw-items-center tw-font-sans tw-text-s"])}
     >
         {decorator && (
-            <span className="tw-flex-shrink-0" data-test-id="menu-item-decorator">
+            <span
+                className={merge(["tw-flex-shrink-0", size === MenuItemContentSize.Large ? "tw-pr-3" : "tw-pr-2"])}
+                data-test-id="menu-item-decorator"
+            >
                 {cloneElement(decorator, {
                     size: size === MenuItemContentSize.Small ? IconSize.Size16 : IconSize.Size20,
                 })}
             </span>
         )}
-        <div className="tw-flex-1 tw-overflow-hidden tw-overflow-ellipsis tw-whitespace-nowrap">
+        <div
+            className={merge([
+                "tw-flex-1 tw-overflow-hidden tw-overflow-ellipsis tw-whitespace-nowrap",
+                size === MenuItemContentSize.Large ? "tw-pr-3" : "tw-pr-2",
+            ])}
+        >
             <div
                 data-test-id="menu-item-title"
                 className="tw-select-none"

--- a/src/components/Trigger/Trigger.tsx
+++ b/src/components/Trigger/Trigger.tsx
@@ -35,7 +35,7 @@ export const Trigger: FC<TriggerProps> = ({
         <div
             data-test-id="trigger"
             className={merge([
-                "tw-group tw-relative tw-flex tw-w-full tw-items-center tw-justify-between tw-border tw-rounded tw-gap-2 tw-transition-colors tw-pr-3 tw-min-h-[36px]",
+                "tw-group tw-relative tw-flex tw-w-full tw-items-center tw-justify-between tw-border tw-rounded tw-transition-colors tw-min-h-[36px]",
                 isFocusVisible && FOCUS_STYLE,
                 disabled
                     ? "tw-border-black-5 tw-bg-black-5 tw-pointer-events-none"
@@ -69,7 +69,7 @@ export const Trigger: FC<TriggerProps> = ({
                 aria-hidden="true"
                 tabIndex={-1}
                 className={merge([
-                    "tw-p-0",
+                    "tw-p-0 tw-absolute tw-right-3",
                     disabled
                         ? "tw-pointer-events-none tw-text-black-40"
                         : merge(["group-hover:tw-text-black", isOpen ? "tw-text-black-100" : "tw-text-black-80"]),


### PR DESCRIPTION
This fix eliminates gaps that don't handle click events around the dropdown text and the caret icon on the right-hand side.