### PR TITLE
Fix: Add padding to text input to prevent icon from covering it

### DIFF
--- a/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
@@ -33,7 +33,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
                 {...focusProps}
                 id={useMemoizedId(id)}
                 className={merge([
-                    "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none tw-py-2 tw-px-3 tw-min-h-[34px]",
+                    "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none tw-py-2 tw-px-3 tw-min-h-[34px] tw-pr-10",
                     !currentColor && "tw-text-black-60",
                     disabled && "tw-text-black-40",
                 ])}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -97,7 +97,7 @@ export const Dropdown: FC<DropdownProps> = ({
                     ref={ref}
                     data-test-id="dropdown-trigger"
                     className={merge([
-                        "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none",
+                        "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none tw-pr-10",
                         size === DropdownSize.Small ? "tw-py-2 tw-px-3 tw-min-h-[34px]" : "tw-p-5 tw-min-h-[60px]",
                         !activeItem && "tw-text-black-60",
                         disabled && "tw-text-black-40",


### PR DESCRIPTION
Fixes the issue of having an absolutely positioned icon in the text input covering part of the text on smaller width sizes.