### PR TITLE
fix(slider): slider focus ring inside overlays

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,6 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 
 import { IconProps } from "@foundation/Icon/IconProps";
 import { useMemoizedId } from "@hooks/useMemoizedId";

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -12,7 +12,7 @@ import { RadioGroupState, useRadioGroupState } from "@react-stately/radio";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
 import { merge } from "@utilities/merge";
 import { AnimateSharedLayout, motion } from "framer-motion";
-import React, { FC, MouseEvent, ReactElement, useMemo, useRef } from "react";
+import React, { FC, ReactElement, useMemo, useRef } from "react";
 
 export type IconItem = {
     id: string;
@@ -59,8 +59,7 @@ const SliderItem = (props: SliderItemProps) => {
     );
     const { isFocusVisible, focusProps } = useFocusRing();
 
-    const handleLabelClick = (event: MouseEvent<HTMLLabelElement>) => {
-        event.preventDefault();
+    const handleMockLabelClick = () => {
         radioGroupState.setSelectedValue(item.id);
         ref.current?.focus();
         setInteractionModality("pointer");
@@ -86,9 +85,13 @@ const SliderItem = (props: SliderItemProps) => {
                     aria-hidden="true"
                 />
             )}
-            <label
-                onClick={handleLabelClick}
-                htmlFor={isActive ? id : undefined}
+            <div
+                // Since framer-motion sets `visibility` to `visible` which leads
+                // to undesired side effects for example when this component is
+                // used inside an `AccordionItem` that's why we explicitly
+                // set the prop to `inherit` so framer leave it as is.
+                role="none"
+                onClick={handleMockLabelClick}
                 data-test-id={
                     isIconItem(item)
                         ? "slider-item-icon"
@@ -108,7 +111,7 @@ const SliderItem = (props: SliderItemProps) => {
                 <span className="tw-overflow-hidden tw-overflow-ellipsis tw-whitespace-nowrap">
                     {isIconItem(item) ? <span aria-label={item.ariaLabel}>{item.icon}</span> : item.value.toString()}
                 </span>
-            </label>
+            </div>
         </li>
     );
 };

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,4 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 
 import { IconProps } from "@foundation/Icon/IconProps";
 import { useMemoizedId } from "@hooks/useMemoizedId";
@@ -9,7 +11,7 @@ import { RadioGroupState, useRadioGroupState } from "@react-stately/radio";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
 import { merge } from "@utilities/merge";
 import { AnimateSharedLayout, motion } from "framer-motion";
-import React, { FC, ReactElement, useMemo, useRef } from "react";
+import React, { FC, MouseEvent, ReactElement, useMemo, useRef } from "react";
 
 export type IconItem = {
     id: string;
@@ -56,6 +58,11 @@ const SliderItem = (props: SliderItemProps) => {
     );
     const { isFocusVisible, focusProps } = useFocusRing();
 
+    const handleLabelClick = (event: MouseEvent<HTMLLabelElement>) => {
+        event.preventDefault();
+        radioGroupState.setSelectedValue(item.id);
+    };
+
     return (
         <li key={item.id} className="tw-relative">
             {isActive && (
@@ -77,6 +84,7 @@ const SliderItem = (props: SliderItemProps) => {
                 />
             )}
             <label
+                onClick={handleLabelClick}
                 htmlFor={isActive ? id : undefined}
                 data-test-id={
                     isIconItem(item)

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -86,10 +86,8 @@ const SliderItem = (props: SliderItemProps) => {
                 />
             )}
             <div
-                // Since framer-motion sets `visibility` to `visible` which leads
-                // to undesired side effects for example when this component is
-                // used inside an `AccordionItem` that's why we explicitly
-                // set the prop to `inherit` so framer leave it as is.
+                // TODO: Change element back to label when bug #2380 from @react-aria is fixed
+                // https://github.com/adobe/react-spectrum/issues/2380
                 role="none"
                 onClick={handleMockLabelClick}
                 data-test-id={

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -60,9 +60,11 @@ const SliderItem = (props: SliderItemProps) => {
     const { isFocusVisible, focusProps } = useFocusRing();
 
     const handleMockLabelClick = () => {
-        radioGroupState.setSelectedValue(item.id);
-        ref.current?.focus();
-        setInteractionModality("pointer");
+        if (!disabled) {
+            radioGroupState.setSelectedValue(item.id);
+            ref.current?.focus();
+            setInteractionModality("pointer");
+        }
     };
 
     return (

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -5,6 +5,7 @@
 import { IconProps } from "@foundation/Icon/IconProps";
 import { useMemoizedId } from "@hooks/useMemoizedId";
 import { useFocusRing } from "@react-aria/focus";
+import { setInteractionModality } from "@react-aria/interactions";
 import { useRadio, useRadioGroup } from "@react-aria/radio";
 import { VisuallyHidden } from "@react-aria/visually-hidden";
 import { RadioGroupState, useRadioGroupState } from "@react-stately/radio";
@@ -61,6 +62,8 @@ const SliderItem = (props: SliderItemProps) => {
     const handleLabelClick = (event: MouseEvent<HTMLLabelElement>) => {
         event.preventDefault();
         radioGroupState.setSelectedValue(item.id);
+        ref.current?.focus();
+        setInteractionModality("pointer");
     };
 
     return (


### PR DESCRIPTION
This fixes the issue that causes a "focus visible" ring to appear when the slider label is pressed for the second time inside an overlay.
Clickup link: https://app.clickup.com/t/1p0hg4a