### PR TITLE
fix(color-picker): sticky preview behaviour

### DIFF
--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -43,7 +43,7 @@ export const ColorPicker: FC<ColorPickerProps> = ({
     }, [currentColor]);
 
     return (
-        <div className="tw-w-[400px]">
+        <div className="tw-w-[400px] tw-relative">
             <ColorPreview color={color} format={currentFormat} />
             <div className="tw-p-6 tw-flex tw-flex-col tw-gap-5">
                 {palettes && (
@@ -77,13 +77,15 @@ const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format
     }, [hex, rgba, alpha]);
 
     return (
-        <div
-            className={merge(["tw-flex tw-justify-center tw-p-7 tw-text-m tw-gap-2"])}
-            style={{ background: backgroundColor, color: labelColor }}
-            data-test-id="color-preview"
-        >
-            {name && <span className="tw-font-bold">{name}</span>}
-            <span className={name ? "" : "tw-font-bold"}>{displayValue}</span>
+        <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">
+            <div
+                className="tw-flex tw-justify-center tw-p-7 tw-text-m tw-gap-2"
+                style={{ background: backgroundColor, color: labelColor }}
+                data-test-id="color-preview"
+            >
+                {name && <span className="tw-font-bold">{name}</span>}
+                <span className={name ? "" : "tw-font-bold"}>{displayValue}</span>
+            </div>
         </div>
     );
 };

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Slider } from "@components/Slider/Slider";
 import { getBackgroundColor, getColorDisplayValue } from "@utilities/colors";
+import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useMemo, useState } from "react";
 // @ts-ignore
 import { getContrastingColor } from "react-color/lib/helpers/color";
@@ -72,7 +73,7 @@ const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format
     const backgroundColor = getBackgroundColor(color);
     const displayValue = getColorDisplayValue(color, format);
     const labelColor = useMemo(() => {
-        return alpha && alpha >= 0.3 ? getContrastingColor(hex) : null;
+        return alpha && alpha < 0.3 ? null : getContrastingColor(hex);
     }, [hex, rgba, alpha]);
 
     return (

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Slider } from "@components/Slider/Slider";
 import { getBackgroundColor, getColorDisplayValue } from "@utilities/colors";
-import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useMemo, useState } from "react";
 // @ts-ignore
 import { getContrastingColor } from "react-color/lib/helpers/color";
@@ -73,13 +72,13 @@ const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format
     const backgroundColor = getBackgroundColor(color);
     const displayValue = getColorDisplayValue(color, format);
     const labelColor = useMemo(() => {
-        return alpha && alpha < 0.3 ? "#000000" : getContrastingColor(hex);
+        return alpha && alpha >= 0.3 ? getContrastingColor(hex) : null;
     }, [hex, rgba, alpha]);
 
     return (
         <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">
             <div
-                className="tw-flex tw-justify-center tw-p-7 tw-text-m tw-gap-2"
+                className={"tw-flex tw-justify-center tw-p-7 tw-text-m tw-text-black dark:tw-text-white tw-gap-2"}
                 style={{ background: backgroundColor, color: labelColor }}
                 data-test-id="color-preview"
             >

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Slider } from "@components/Slider/Slider";
 import { getBackgroundColor, getColorDisplayValue } from "@utilities/colors";
-import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useMemo, useState } from "react";
 // @ts-ignore
 import { getContrastingColor } from "react-color/lib/helpers/color";
@@ -79,7 +78,7 @@ const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format
     return (
         <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">
             <div
-                className={"tw-flex tw-justify-center tw-p-7 tw-text-m tw-text-black dark:tw-text-white tw-gap-2"}
+                className="tw-flex tw-justify-center tw-p-7 tw-text-m tw-text-black dark:tw-text-white tw-gap-2"
                 style={{ background: backgroundColor, color: labelColor }}
                 data-test-id="color-preview"
             >

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -85,7 +85,7 @@ const OverlayComponent: ForwardRefRenderFunction<HTMLDivElement, OverlayProps> =
         <div
             {...mergeProps(overlayProps, dialogProps, modalProps, positionProps, overlayTriggerProps)}
             ref={ref}
-            className="tw-max-h-full tw-shadow-mid tw-min-w-[400px] tw-outline-none"
+            className="tw-max-h-full tw-overflow-y-auto tw-shadow-mid tw-min-w-[400px] tw-outline-none"
         >
             <div
                 ref={scrollRef}


### PR DESCRIPTION
- Adds a new wrapper element around the color preview with sticky positioning and filled background color so that text scrolling behind is not visible if the alpha is not 1
- Label text is set to white if in dark mode and alpha is below 0.3
- Added overflow: auto to Flyout since default CSS behavior is overflow: visible