### PR TITLE
fix(color-picker): filter empty palettes

### DIFF
--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -105,7 +105,7 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
                               </ul>
                           </li>
                       ))
-                    : "No Colors Found"}
+                    : "No colors found"}
             </ul>
         </div>
     );

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -105,7 +105,7 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
                               </ul>
                           </li>
                       ))
-                    : "No Colors found"}
+                    : "No Colors Found"}
             </ul>
         </div>
     );

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -47,6 +47,8 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
         return () => clearTimeout(timer);
     }, [query]);
 
+    const palettesWithColors = palettes.filter((palette) => !!palette.colors.length);
+
     return (
         <div className="tw-flex tw-flex-col tw-gap-5" data-test-id="brand-color-picker">
             <div className="tw-flex tw-gap-3">
@@ -68,8 +70,8 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
                 </div>
             </div>
             <ul className="tw-flex tw-flex-col tw-gap-5">
-                {palettes.length
-                    ? palettes.map(({ id, title, colors }) => (
+                {palettesWithColors.length
+                    ? palettesWithColors.map(({ id, title, colors }) => (
                           <li key={id} className="tw-flex tw-flex-col tw-gap-3">
                               <p className="tw-text-black dark:tw-text-white">{title}</p>
                               <ul

--- a/src/components/ColorPicker/ColorPicker.spec.tsx
+++ b/src/components/ColorPicker/ColorPicker.spec.tsx
@@ -74,6 +74,13 @@ describe("ColorPicker Component", () => {
         cy.get(TEXT_INPUT_ID).clear().type("red");
         cy.get(BRAND_COLOR_ID).should("have.length", 6);
         cy.get(TEXT_INPUT_ID).clear().type("foo");
-        cy.get(BRAND_COLOR_PICKER_ID).children("ul").should("contain", "No Colors found");
+        cy.get(BRAND_COLOR_PICKER_ID).children("ul").should("contain", "No Colors Found");
+    });
+
+    it("should display message if no brand colors are found in palettes", () => {
+        mount(<Component palettes={EXAMPLE_PALETTES.map((palette) => ({ ...palette, colors: [] }))} />);
+        cy.get(BRAND_COLOR_PICKER_ID).should("exist");
+        cy.get(BRAND_COLOR_ID).should("not.exist");
+        cy.get(BRAND_COLOR_PICKER_ID).children("ul").should("contain", "No Colors Found");
     });
 });

--- a/src/components/ColorPicker/ColorPicker.spec.tsx
+++ b/src/components/ColorPicker/ColorPicker.spec.tsx
@@ -74,13 +74,13 @@ describe("ColorPicker Component", () => {
         cy.get(TEXT_INPUT_ID).clear().type("red");
         cy.get(BRAND_COLOR_ID).should("have.length", 6);
         cy.get(TEXT_INPUT_ID).clear().type("foo");
-        cy.get(BRAND_COLOR_PICKER_ID).children("ul").should("contain", "No Colors Found");
+        cy.get(BRAND_COLOR_PICKER_ID).children("ul").should("contain", "No colors found");
     });
 
     it("should display message if no brand colors are found in palettes", () => {
         mount(<Component palettes={EXAMPLE_PALETTES.map((palette) => ({ ...palette, colors: [] }))} />);
         cy.get(BRAND_COLOR_PICKER_ID).should("exist");
         cy.get(BRAND_COLOR_ID).should("not.exist");
-        cy.get(BRAND_COLOR_PICKER_ID).children("ul").should("contain", "No Colors Found");
+        cy.get(BRAND_COLOR_PICKER_ID).children("ul").should("contain", "No colors found");
     });
 });


### PR DESCRIPTION
- Empty color palettes are no longer displayed in the picker list
- Removed Titlecase on "Colors"
Clickup Ticket: https://app.clickup.com/t/1zngnky