### PR TITLE
fix(slider): prevent transition on unrelated re-renders

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -63,7 +63,7 @@ const SliderItem = (props: SliderItemProps) => {
                     key={id}
                     initial={false}
                     layoutId={id}
-                    layoutDependency={id}
+                    layoutDependency={isActive}
                     className={merge([
                         "tw-absolute tw--inset-px tw-h-full tw-box-content tw-border tw-rounded tw-pointer-events-none",
                         disabled ? "tw-border-black-20 tw-bg-black-0" : "tw-border-black tw-bg-white",

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -63,6 +63,7 @@ const SliderItem = (props: SliderItemProps) => {
                     key={id}
                     initial={false}
                     layoutId={id}
+                    layoutDependency={id}
                     className={merge([
                         "tw-absolute tw--inset-px tw-h-full tw-box-content tw-border tw-rounded tw-pointer-events-none",
                         disabled ? "tw-border-black-20 tw-bg-black-0" : "tw-border-black tw-bg-white",

--- a/src/foundation/Icon/Generated/index.ts
+++ b/src/foundation/Icon/Generated/index.ts
@@ -1,5 +1,4 @@
-
-        export { default as IconAcademy } from "./IconAcademy";
+export { default as IconAcademy } from "./IconAcademy";
 export { default as IconActions } from "./IconActions";
 export { default as IconActivities } from "./IconActivities";
 export { default as IconActivity } from "./IconActivity";
@@ -255,4 +254,3 @@ export { default as IconVolumeOff } from "./IconVolumeOff";
 export { default as IconVolumeOn } from "./IconVolumeOn";
 export { default as IconWorkflow } from "./IconWorkflow";
 export { default as IconZoom } from "./IconZoom";
-    

--- a/src/foundation/Icon/Generated/index.ts
+++ b/src/foundation/Icon/Generated/index.ts
@@ -1,4 +1,5 @@
-export { default as IconAcademy } from "./IconAcademy";
+
+        export { default as IconAcademy } from "./IconAcademy";
 export { default as IconActions } from "./IconActions";
 export { default as IconActivities } from "./IconActivities";
 export { default as IconActivity } from "./IconActivity";
@@ -254,3 +255,4 @@ export { default as IconVolumeOff } from "./IconVolumeOff";
 export { default as IconVolumeOn } from "./IconVolumeOn";
 export { default as IconWorkflow } from "./IconWorkflow";
 export { default as IconZoom } from "./IconZoom";
+    


### PR DESCRIPTION
Issue: https://app.clickup.com/t/1u9qpk3
- Added layoutDependecy prop so that transition only occurs if the active item changes