### PR TITLE
refactor(color-picker)!: simplify color data structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
                 "@svgr/plugin-svgo": "6.1.2",
                 "@types/react": "17.0.38",
                 "@types/react-dom": "17.0.11",
+                "@types/tinycolor2": "^1.4.3",
                 "@vitejs/plugin-react-refresh": "1.3.6",
                 "autoprefixer": "10.4.1",
                 "chalk": "5.0.0",
@@ -6592,6 +6593,12 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
             "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
+            "dev": true
+        },
+        "node_modules/@types/tinycolor2": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.3.tgz",
+            "integrity": "sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ==",
             "dev": true
         },
         "node_modules/@types/uglify-js": {
@@ -30458,6 +30465,12 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
             "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
+            "dev": true
+        },
+        "@types/tinycolor2": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.3.tgz",
+            "integrity": "sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ==",
             "dev": true
         },
         "@types/uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
                 "slate-history": "^0.66.0",
                 "slate-hyperscript": "^0.67.0",
                 "slate-react": "^0.72.0",
+                "tinycolor2": "^1.4.2",
                 "xstate": "^4.25.0"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
         "@svgr/plugin-svgo": "6.1.2",
         "@types/react": "17.0.38",
         "@types/react-dom": "17.0.11",
+        "@types/tinycolor2": "^1.4.3",
         "@vitejs/plugin-react-refresh": "1.3.6",
         "autoprefixer": "10.4.1",
         "chalk": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
         "slate-history": "^0.66.0",
         "slate-hyperscript": "^0.67.0",
         "slate-react": "^0.72.0",
+        "tinycolor2": "^1.4.2",
         "xstate": "^4.25.0"
     }
 }

--- a/src/components/ColorInputFlyout/ColorInputTitle.tsx
+++ b/src/components/ColorInputFlyout/ColorInputTitle.tsx
@@ -1,4 +1,5 @@
-import { getAlphaPercent, getColorDisplayValue } from "@utilities/colors";
+import { getColorDisplayValue } from "@utilities/colors";
+import tinycolor from "tinycolor2";
 import React, { FC } from "react";
 import { Color, ColorFormat } from "../../types/colors";
 
@@ -8,14 +9,15 @@ type Props = {
 };
 
 export const ColorInputTitle: FC<Props> = ({ currentColor, format }) => {
-    const { name, alpha } = currentColor;
+    const { name, a } = currentColor;
+    const parsedColor = tinycolor(currentColor);
     const colorValue = getColorDisplayValue(currentColor, format, false);
 
     return (
         <div className="tw-text-black-100">
             {name || colorValue}
-            {format === ColorFormat.Hex && alpha && alpha < 1 && (
-                <span className="tw-text-black-60"> {getAlphaPercent(alpha)}</span>
+            {format === ColorFormat.Hex && a && a < 1 && (
+                <span className="tw-text-black-60"> {parsedColor.getAlpha()}</span>
             )}
         </div>
     );

--- a/src/components/ColorInputFlyout/ColorInputTitle.tsx
+++ b/src/components/ColorInputFlyout/ColorInputTitle.tsx
@@ -17,7 +17,7 @@ export const ColorInputTitle: FC<Props> = ({ currentColor, format }) => {
         <div className="tw-text-black-100">
             {name || colorValue}
             {format === ColorFormat.Hex && a && a < 1 && (
-                <span className="tw-text-black-60"> {parsedColor.getAlpha()}</span>
+                <span className="tw-text-black-60">{` ${Math.trunc(parsedColor.getAlpha() * 100)} %`}</span>
             )}
         </div>
     );

--- a/src/components/ColorInputFlyout/ColorInputTitle.tsx
+++ b/src/components/ColorInputFlyout/ColorInputTitle.tsx
@@ -1,6 +1,8 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
 import { getColorDisplayValue } from "@utilities/colors";
-import tinycolor from "tinycolor2";
 import React, { FC } from "react";
+import tinycolor from "tinycolor2";
 import { Color, ColorFormat } from "../../types/colors";
 
 type Props = {

--- a/src/components/ColorInputFlyout/ColorInputTitle.tsx
+++ b/src/components/ColorInputFlyout/ColorInputTitle.tsx
@@ -1,5 +1,3 @@
-/* (c) Copyright Frontify Ltd., all rights reserved. */
-
 import { getColorDisplayValue } from "@utilities/colors";
 import React, { FC } from "react";
 import tinycolor from "tinycolor2";

--- a/src/components/ColorInputFlyout/ColorInputTitle.tsx
+++ b/src/components/ColorInputFlyout/ColorInputTitle.tsx
@@ -1,3 +1,5 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
 import { getColorDisplayValue } from "@utilities/colors";
 import React, { FC } from "react";
 import tinycolor from "tinycolor2";

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
@@ -10,7 +10,8 @@ import React, { FC, useState } from "react";
 import { ColorPickerFlyout } from "./ColorPickerFlyout";
 
 const TRIGGER_ID = "[data-test-id=trigger]";
-const TEST_COLOR = { hex: "#0085ff", rgb: "rgb(0, 133, 255)" };
+const TEST_COLOR = { r: 0, g: 133, b: 255 };
+const TEST_COLOR_HEX = "#0085ff";
 
 type Props = {
     palettes?: Palette[];
@@ -41,14 +42,14 @@ describe("ColorInputFlyout Component", () => {
         cy.get(BRAND_COLOR_ID).first().click();
         cy.get(BUTTON_ID).last().click();
         cy.get(TRIGGER_ID).should("contain", "90");
-        cy.get(MENU_ITEM_DECORATOR_ID).children("span").invoke("attr", "style").should("include", "rgb(153, 33, 54)");
+        cy.get(MENU_ITEM_DECORATOR_ID).children("span").invoke("attr", "style").should("include", "rgb(174, 38, 61)");
     });
 
     it("should render with initial color", () => {
-        mount(<Component currentColor={{ hex: TEST_COLOR.hex, alpha: 1 }} />);
+        mount(<Component currentColor={TEST_COLOR} />);
 
-        cy.get(TRIGGER_ID).should("contain", TEST_COLOR.hex).click();
-        cy.get(COLOR_PREVIEW_ID).should("contain", TEST_COLOR.hex);
-        cy.get(MENU_ITEM_DECORATOR_ID).children("span").invoke("attr", "style").should("include", TEST_COLOR.rgb);
+        cy.get(TRIGGER_ID).should("contain", TEST_COLOR_HEX).click();
+        cy.get(COLOR_PREVIEW_ID).should("contain", TEST_COLOR_HEX);
+        cy.get(MENU_ITEM_DECORATOR_ID).children("span").invoke("attr", "style").should("include", "rgb(0, 133, 255)");
     });
 });

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
@@ -42,7 +42,7 @@ describe("ColorInputFlyout Component", () => {
         cy.get(BRAND_COLOR_ID).first().click();
         cy.get(BUTTON_ID).last().click();
         cy.get(TRIGGER_ID).should("contain", "90");
-        cy.get(MENU_ITEM_DECORATOR_ID).children("span").invoke("attr", "style").should("include", "rgb(174, 38, 61)");
+        cy.get(MENU_ITEM_DECORATOR_ID).children("span").invoke("attr", "style").should("include", "rgb(153, 33, 54)");
     });
 
     it("should render with initial color", () => {

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
@@ -5,8 +5,8 @@ import { BRAND_COLOR_ID, COLOR_PREVIEW_ID } from "@components/ColorPicker/ColorP
 import { MENU_ITEM_DECORATOR_ID } from "@components/MenuItem/MenuItem.spec";
 import { mount } from "@cypress/react";
 import { EXAMPLE_PALETTES } from "@utilities/colors";
-import { Color, Palette } from "../../types/colors";
 import React, { FC, useState } from "react";
+import { Color, Palette } from "../../types/colors";
 import { ColorPickerFlyout } from "./ColorPickerFlyout";
 
 const TRIGGER_ID = "[data-test-id=trigger]";

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
@@ -50,6 +50,9 @@ describe("ColorInputFlyout Component", () => {
 
         cy.get(TRIGGER_ID).should("contain", TEST_COLOR_HEX).click();
         cy.get(COLOR_PREVIEW_ID).should("contain", TEST_COLOR_HEX);
-        cy.get(MENU_ITEM_DECORATOR_ID).children("span").invoke("attr", "style").should("include", "rgb(0, 133, 255)");
+        cy.get(MENU_ITEM_DECORATOR_ID)
+            .children("span")
+            .invoke("attr", "style")
+            .should("include", `rgb(${Object.values(TEST_COLOR).join(", ")})`);
     });
 });

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
@@ -4,9 +4,9 @@ import { BUTTON_ID } from "@components/Button/Button.spec";
 import { BRAND_COLOR_ID, COLOR_PREVIEW_ID } from "@components/ColorPicker/ColorPicker.spec";
 import { MENU_ITEM_DECORATOR_ID } from "@components/MenuItem/MenuItem.spec";
 import { mount } from "@cypress/react";
-import { EXAMPLE_PALETTES } from "@utilities/colors";
 import React, { FC, useState } from "react";
 import { Color, Palette } from "../../types/colors";
+import { EXAMPLE_PALETTES } from "../ColorPicker/ColorPicker.stories";
 import { ColorPickerFlyout } from "./ColorPickerFlyout";
 
 const TRIGGER_ID = "[data-test-id=trigger]";

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
@@ -6,7 +6,7 @@ import { MENU_ITEM_DECORATOR_ID } from "@components/MenuItem/MenuItem.spec";
 import { mount } from "@cypress/react";
 import React, { FC, useState } from "react";
 import { Color, Palette } from "../../types/colors";
-import { EXAMPLE_PALETTES } from "../ColorPicker/ColorPicker.stories";
+import { EXAMPLE_PALETTES } from "../ColorPicker/example-palettes";
 import { ColorPickerFlyout } from "./ColorPickerFlyout";
 
 const TRIGGER_ID = "[data-test-id=trigger]";

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.spec.tsx
@@ -42,7 +42,7 @@ describe("ColorInputFlyout Component", () => {
         cy.get(BRAND_COLOR_ID).first().click();
         cy.get(BUTTON_ID).last().click();
         cy.get(TRIGGER_ID).should("contain", "90");
-        cy.get(MENU_ITEM_DECORATOR_ID).children("span").invoke("attr", "style").should("include", "rgb(153, 33, 54)");
+        cy.get(MENU_ITEM_DECORATOR_ID).children("span").invoke("attr", "style").should("include", "rgb(174, 38, 61)");
     });
 
     it("should render with initial color", () => {

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.stories.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.stories.tsx
@@ -1,9 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Meta, Story } from "@storybook/react";
-import { EXAMPLE_PALETTES } from "@utilities/colors";
 import React, { useState } from "react";
 import { Color } from "../../types/colors";
+import { EXAMPLE_PALETTES } from "../ColorPicker/ColorPicker.stories";
 import { ColorPickerFlyout as ColorPickerFlyoutComponent, ColorPickerFlyoutProps } from "./ColorPickerFlyout";
 
 // eslint-disable-next-line import/no-default-export

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.stories.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.stories.tsx
@@ -2,8 +2,8 @@
 
 import { Meta, Story } from "@storybook/react";
 import { EXAMPLE_PALETTES } from "@utilities/colors";
-import { Color } from "../../types/colors";
 import React, { useState } from "react";
+import { Color } from "../../types/colors";
 import { ColorPickerFlyout as ColorPickerFlyoutComponent, ColorPickerFlyoutProps } from "./ColorPickerFlyout";
 
 // eslint-disable-next-line import/no-default-export

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.stories.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.stories.tsx
@@ -3,7 +3,7 @@
 import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
 import { Color } from "../../types/colors";
-import { EXAMPLE_PALETTES } from "../ColorPicker/ColorPicker.stories";
+import { EXAMPLE_PALETTES } from "../ColorPicker/example-palettes";
 import { ColorPickerFlyout as ColorPickerFlyoutComponent, ColorPickerFlyoutProps } from "./ColorPickerFlyout";
 
 // eslint-disable-next-line import/no-default-export

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
@@ -50,7 +50,7 @@ export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
                 setFormat={setCurrentFormat}
                 palettes={palettes}
                 showPreview={false}
-                currentColor={currentColor || { hex: "#ffffff" }}
+                currentColor={currentColor || { r: 255, g: 255, b: 255 }}
                 onSelect={onSelect}
             />
         </Flyout>

--- a/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerFlyout.tsx
@@ -33,7 +33,7 @@ export const ColorPickerFlyout: FC<ColorPickerFlyoutProps> = ({
             onClick={onClick}
             onClose={onClose}
             isOpen={open}
-            fixedHeader={<ColorPreview color={currentColor || { hex: "#ffffff" }} format={currentFormat} />}
+            fixedHeader={<ColorPreview color={currentColor || { r: 255, g: 255, b: 255 }} format={currentFormat} />}
             onOpenChange={(isOpen) => setOpen(isOpen)}
             trigger={
                 <ColorInputTrigger

--- a/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
@@ -6,9 +6,9 @@ import IconColors from "@foundation/Icon/Generated/IconColors";
 import { IconSize } from "@foundation/Icon/IconSize";
 import { useMemoizedId } from "@hooks/useMemoizedId";
 import { useFocusRing } from "@react-aria/focus";
-import { getBackgroundColor } from "@utilities/colors";
 import { merge } from "@utilities/merge";
 import React, { FC } from "react";
+import tinycolor from "tinycolor2";
 import { ColorFormat } from "../../types/colors";
 import { ColorInputTitle } from "./ColorInputTitle";
 import { ColorPickerFlyoutProps } from "./ColorPickerFlyout";
@@ -26,6 +26,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
     disabled = false,
 }) => {
     const { isFocusVisible, focusProps } = useFocusRing();
+    const backgroundColor = currentColor ? tinycolor(currentColor).toRgbString() : "";
 
     return (
         <Trigger isOpen={isOpen} disabled={disabled} isFocusVisible={isFocusVisible}>
@@ -49,7 +50,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
                                     "tw-h-4 tw-w-4 tw-rounded tw-flex tw-items-center tw-justify-center",
                                     disabled && "tw-opacity-50",
                                 ])}
-                                style={{ background: getBackgroundColor(currentColor) }}
+                                style={{ background: backgroundColor }}
                             />
                         ) : (
                             <span className="tw-text-black-70">

--- a/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
@@ -50,7 +50,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
                                     "tw-h-4 tw-w-4 tw-rounded tw-flex tw-items-center tw-justify-center",
                                     disabled && "tw-opacity-50",
                                 ])}
-                                style={{ background: backgroundColor }}
+                                style={{ backgroundColor }}
                             />
                         ) : (
                             <span className="tw-text-black-70">

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -90,9 +90,10 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
                                               onClick={() => onSelect(color)}
                                           >
                                               <span
-                                                  className={`tw-h-8 tw-w-8 tw-mr-2 tw-rounded tw-flex tw-items-center tw-justify-center ${
-                                                      isColorLight(color) ? "tw-text-black" : "tw-text-white"
-                                                  }`}
+                                                  className={merge([
+                                                      "tw-h-8 tw-w-8 tw-mr-2 tw-rounded tw-flex tw-items-center tw-justify-center ",
+                                                      isColorLight(color) ? "tw-text-black" : "tw-text-white",
+                                                  ])}
                                                   style={{ background: tinycolor(color).toRgbString() }}
                                               >
                                                   {color.r === currentColor.r &&

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -5,9 +5,9 @@ import IconImageGrid2 from "@foundation/Icon/Generated/IconImageGrid2";
 import IconListBullets from "@foundation/Icon/Generated/IconListBullets";
 import IconSearch from "@foundation/Icon/Generated/IconSearch";
 import { IconSize } from "@foundation/Icon/IconSize";
-import { toColor } from "@utilities/colors";
 import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useState } from "react";
+import tinycolor from "tinycolor2";
 import { ColorPickerProps } from "./ColorPicker";
 
 const find = (haystack?: string, needle = "") =>
@@ -81,18 +81,20 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
                                   ])}
                               >
                                   {colors.map((color) => (
-                                      <li key={color.hex} data-test-id="brand-color">
+                                      <li key={color.name} data-test-id="brand-color">
                                           <button
                                               className="tw-flex tw-overflow-hidden tw-w-full"
-                                              onClick={() => onSelect(toColor(color, color))}
+                                              onClick={() => onSelect(color)}
                                           >
                                               <span
                                                   className="tw-h-8 tw-w-8 tw-mr-2 tw-rounded tw-flex tw-items-center tw-justify-center tw-text-white"
-                                                  style={{ background: color.hex }}
+                                                  style={{ background: tinycolor(color).toRgbString() }}
                                               >
-                                                  {color.hex === currentColor.hex && (
-                                                      <IconCheck size={IconSize.Size20} />
-                                                  )}
+                                                  {color.r === currentColor.r &&
+                                                      color.g === currentColor.g &&
+                                                      color.b === currentColor.b && (
+                                                          <IconCheck size={IconSize.Size20} />
+                                                      )}
                                               </span>
                                               {view === BrandColorView.List && (
                                                   <span className="tw-h-8 tw-flex-grow tw-flex tw-items-center tw-text-left">

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -1,3 +1,5 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
 import { Slider } from "@components/Slider/Slider";
 import { TextInput } from "@components/TextInput/TextInput";
 import IconCheck from "@foundation/Icon/Generated/IconCheck";

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -97,7 +97,8 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
                                               >
                                                   {color.r === currentColor.r &&
                                                       color.g === currentColor.g &&
-                                                      color.b === currentColor.b && (
+                                                      color.b === currentColor.b &&
+                                                      color.a === currentColor.a && (
                                                           <IconCheck size={IconSize.Size20} />
                                                       )}
                                               </span>

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -5,6 +5,7 @@ import IconImageGrid2 from "@foundation/Icon/Generated/IconImageGrid2";
 import IconListBullets from "@foundation/Icon/Generated/IconListBullets";
 import IconSearch from "@foundation/Icon/Generated/IconSearch";
 import { IconSize } from "@foundation/Icon/IconSize";
+import { isColorLight } from "@utilities/colors";
 import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useState } from "react";
 import tinycolor from "tinycolor2";
@@ -87,7 +88,9 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
                                               onClick={() => onSelect(color)}
                                           >
                                               <span
-                                                  className="tw-h-8 tw-w-8 tw-mr-2 tw-rounded tw-flex tw-items-center tw-justify-center tw-text-white"
+                                                  className={`tw-h-8 tw-w-8 tw-mr-2 tw-rounded tw-flex tw-items-center tw-justify-center ${
+                                                      isColorLight(color) ? "tw-text-black" : "tw-text-white"
+                                                  }`}
                                                   style={{ background: tinycolor(color).toRgbString() }}
                                               >
                                                   {color.r === currentColor.r &&

--- a/src/components/ColorPicker/ColorPicker.spec.tsx
+++ b/src/components/ColorPicker/ColorPicker.spec.tsx
@@ -21,7 +21,7 @@ type Props = {
     currentColor?: Color;
 };
 
-const Component: FC<Props> = ({ palettes, currentColor = { hex: "#FF0000", alpha: 1 } }) => {
+const Component: FC<Props> = ({ palettes, currentColor = { r: 255, g: 0, b: 0 } }) => {
     const [selectedColor, setSelectedColor] = useState<Color>(currentColor);
     const [currentFormat, setCurrentFormat] = useState(ColorFormat.Hex);
 
@@ -41,7 +41,7 @@ describe("ColorPicker Component", () => {
         mount(<Component />);
 
         cy.get(CUSTOM_COLOR_PICKER_ID).should("exist");
-        cy.get(COLOR_PREVIEW_ID).should("contain", "#FF0000");
+        cy.get(COLOR_PREVIEW_ID).should("contain", "#ff0000");
         cy.get(DROPDOWN_TRIGGER_ID).should("contain", "HEX");
         cy.get(COLOR_INPUT_ID).should("have.length", 2);
         cy.get(DROPDOWN_TRIGGER_ID).click().get(MENU_ITEM_ID).eq(1).click();

--- a/src/components/ColorPicker/ColorPicker.spec.tsx
+++ b/src/components/ColorPicker/ColorPicker.spec.tsx
@@ -4,10 +4,10 @@ import { DROPDOWN_TRIGGER_ID } from "@components/Dropdown/Dropdown.spec";
 import { MENU_ITEM_ID } from "@components/MenuItem/MenuItem.spec";
 import { ICON_ITEM_ID, TEXT_ITEM_ID } from "@components/Slider/Slider.spec";
 import { mount } from "@cypress/react";
-import { EXAMPLE_PALETTES } from "@utilities/colors";
 import React, { FC, useState } from "react";
 import { Color, ColorFormat, Palette } from "../../types/colors";
 import { ColorPicker } from "./ColorPicker";
+import { EXAMPLE_PALETTES } from "./ColorPicker.stories";
 
 export const BRAND_COLOR_ID = "[data-test-id=brand-color]";
 export const COLOR_PREVIEW_ID = "[data-test-id=color-preview]";

--- a/src/components/ColorPicker/ColorPicker.spec.tsx
+++ b/src/components/ColorPicker/ColorPicker.spec.tsx
@@ -7,7 +7,7 @@ import { mount } from "@cypress/react";
 import React, { FC, useState } from "react";
 import { Color, ColorFormat, Palette } from "../../types/colors";
 import { ColorPicker } from "./ColorPicker";
-import { EXAMPLE_PALETTES } from "./ColorPicker.stories";
+import { EXAMPLE_PALETTES } from "./example-palettes";
 
 export const BRAND_COLOR_ID = "[data-test-id=brand-color]";
 export const COLOR_PREVIEW_ID = "[data-test-id=color-preview]";

--- a/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -2,45 +2,9 @@
 
 import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
-import tinycolor from "tinycolor2";
-import { Color, ColorFormat, Palette } from "../../types/colors";
+import { ColorFormat } from "../../types/colors";
 import { ColorPicker, ColorPickerProps } from "./ColorPicker";
-
-const generatePalette = (color: string, amount: number): Color[] => {
-    const sourceColor = tinycolor(color);
-    const palette = [...new Array(amount)].map((_, index) => {
-        const name = (90 - index * 10).toString();
-        const lightColor = sourceColor.lighten(index * 3).toRgb();
-        return {
-            ...lightColor,
-            name,
-        };
-    });
-    return palette;
-};
-
-export const EXAMPLE_PALETTES: Palette[] = [
-    {
-        id: "red",
-        title: "Red",
-        source: "#992136",
-    },
-    {
-        id: "green",
-        title: "Green",
-        source: "#006452",
-    },
-    {
-        id: "yellow",
-        title: "Yellow",
-        source: "#cc9000",
-    },
-].map((palette) => {
-    return {
-        ...palette,
-        colors: generatePalette(palette.source, 6),
-    };
-});
+import { EXAMPLE_PALETTES } from "./example-palettes";
 
 // eslint-disable-next-line import/no-default-export
 export default {

--- a/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -11,7 +11,7 @@ export default {
     title: "Components/Color Picker",
     component: ColorPicker,
     args: {
-        currentColor: { hex: "#5566FF", alpha: 1 },
+        currentColor: { r: 85, g: 102, b: 255 },
     },
     argTypes: {
         onSelect: { action: "Select Color" },

--- a/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,10 +1,46 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Meta, Story } from "@storybook/react";
-import { EXAMPLE_PALETTES } from "@utilities/colors";
 import React, { useState } from "react";
-import { ColorFormat } from "../../types/colors";
+import tinycolor from "tinycolor2";
+import { Color, ColorFormat, Palette } from "../../types/colors";
 import { ColorPicker, ColorPickerProps } from "./ColorPicker";
+
+const generatePalette = (color: string, amount: number): Color[] => {
+    const sourceColor = tinycolor(color);
+    const palette = [...new Array(amount)].map((_, index) => {
+        const name = (90 - index * 10).toString();
+        const lightColor = sourceColor.lighten(index * 3).toRgb();
+        return {
+            ...lightColor,
+            name,
+        };
+    });
+    return palette;
+};
+
+export const EXAMPLE_PALETTES: Palette[] = [
+    {
+        id: "red",
+        title: "Red",
+        source: "#992136",
+    },
+    {
+        id: "green",
+        title: "Green",
+        source: "#006452",
+    },
+    {
+        id: "yellow",
+        title: "Yellow",
+        source: "#cc9000",
+    },
+].map((palette) => {
+    return {
+        ...palette,
+        colors: generatePalette(palette.source, 6),
+    };
+});
 
 // eslint-disable-next-line import/no-default-export
 export default {

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -71,6 +71,7 @@ export const ColorPicker: FC<ColorPickerProps> = ({
 const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format }) => {
     const parsedColor = tinycolor(color);
     const backgroundColor = parsedColor.toRgbString();
+    const colorName = color.name;
     const displayValue = getColorDisplayValue(color, format);
     return (
         <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">
@@ -82,8 +83,8 @@ const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format
                 style={{ background: backgroundColor }}
                 data-test-id="color-preview"
             >
-                {color.name && <span className="tw-font-bold">{color.name}</span>}
-                <span className={color.name ? "" : "tw-font-bold"}>{displayValue}</span>
+                {colorName && <span className="tw-font-bold">{colorName}</span>}
+                <span className={colorName ? "" : "tw-font-bold"}>{displayValue}</span>
             </div>
         </div>
     );

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -1,10 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 import { Slider } from "@components/Slider/Slider";
-import { getBackgroundColor, getColorDisplayValue } from "@utilities/colors";
+import { getColorDisplayValue } from "@utilities/colors";
 import React, { FC, useEffect, useMemo, useState } from "react";
-// @ts-ignore
-import { getContrastingColor } from "react-color/lib/helpers/color";
+import tinycolor from "tinycolor2";
 import { Color, ColorFormat, Palette } from "../../types/colors";
 import { BrandColorPicker } from "./BrandColorPicker";
 import { CustomColorPicker } from "./CustomColorPicker";
@@ -40,7 +39,7 @@ export const ColorPicker: FC<ColorPickerProps> = ({
     const [color, setColor] = useState(currentColor);
 
     useEffect(() => {
-        setColor({ ...currentColor, alpha: currentColor.alpha || 1 });
+        setColor({ ...currentColor, a: currentColor.a || 1 });
     }, [currentColor]);
 
     return (
@@ -69,13 +68,13 @@ export const ColorPicker: FC<ColorPickerProps> = ({
     );
 };
 
-export const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format }) => {
-    const { hex, rgba, name, alpha } = color;
-    const backgroundColor = getBackgroundColor(color);
+const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format }) => {
+    const parsedColor = tinycolor(color);
+    const backgroundColor = parsedColor.toRgbString();
     const displayValue = getColorDisplayValue(color, format);
     const labelColor = useMemo(() => {
-        return alpha && alpha < 0.3 ? null : getContrastingColor(hex);
-    }, [hex, rgba, alpha]);
+        return parsedColor.isLight() ? "#000" : "#fff";
+    }, [parsedColor]);
 
     return (
         <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -73,7 +73,7 @@ const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format
     const backgroundColor = parsedColor.toRgbString();
     const displayValue = getColorDisplayValue(color, format);
     const labelColor = useMemo(() => {
-        return parsedColor.isLight() ? "#000" : "#fff";
+        return parsedColor.isLight() || parsedColor.getAlpha() < 0.25 ? "#000" : "#fff";
     }, [parsedColor]);
 
     return (

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -1,8 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Slider } from "@components/Slider/Slider";
-import { getColorDisplayValue } from "@utilities/colors";
-import React, { FC, useEffect, useMemo, useState } from "react";
+import { getColorDisplayValue, isColorLight } from "@utilities/colors";
+import React, { FC, useEffect, useState } from "react";
 import tinycolor from "tinycolor2";
 import { Color, ColorFormat, Palette } from "../../types/colors";
 import { BrandColorPicker } from "./BrandColorPicker";
@@ -72,15 +72,14 @@ const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format
     const parsedColor = tinycolor(color);
     const backgroundColor = parsedColor.toRgbString();
     const displayValue = getColorDisplayValue(color, format);
-    const labelColor = useMemo(() => {
-        return parsedColor.isLight() || parsedColor.getAlpha() < 0.25 ? "#000" : "#fff";
-    }, [parsedColor]);
-
     return (
         <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">
             <div
-                className="tw-flex tw-justify-center tw-p-7 tw-text-m tw-text-black dark:tw-text-white tw-gap-2"
-                style={{ background: backgroundColor, color: labelColor }}
+                className={`tw-flex tw-justify-center tw-p-7 tw-text-m tw-gap-2 ${
+                    isColorLight(color) ? "tw-text-black" : "tw-text-white"
+                }
+            `}
+                style={{ background: backgroundColor }}
                 data-test-id="color-preview"
             >
                 {color.name && <span className="tw-font-bold">{color.name}</span>}

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -83,8 +83,8 @@ const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format
                 style={{ background: backgroundColor, color: labelColor }}
                 data-test-id="color-preview"
             >
-                {name && <span className="tw-font-bold">{name}</span>}
-                <span className={name ? "" : "tw-font-bold"}>{displayValue}</span>
+                {color.name && <span className="tw-font-bold">{color.name}</span>}
+                <span className={color.name ? "" : "tw-font-bold"}>{displayValue}</span>
             </div>
         </div>
     );

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -68,7 +68,7 @@ export const ColorPicker: FC<ColorPickerProps> = ({
     );
 };
 
-const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format }) => {
+export const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format }) => {
     const parsedColor = tinycolor(color);
     const backgroundColor = parsedColor.toRgbString();
     const colorName = color.name;

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -2,6 +2,7 @@
 
 import { Slider } from "@components/Slider/Slider";
 import { getColorDisplayValue, isColorLight } from "@utilities/colors";
+import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useState } from "react";
 import tinycolor from "tinycolor2";
 import { Color, ColorFormat, Palette } from "../../types/colors";
@@ -76,11 +77,11 @@ export const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color,
     return (
         <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">
             <div
-                className={`tw-flex tw-justify-center tw-p-7 tw-text-m tw-gap-2 ${
-                    isColorLight(color) ? "tw-text-black" : "tw-text-white"
-                }
-            `}
-                style={{ background: backgroundColor }}
+                className={merge([
+                    "tw-flex tw-justify-center tw-p-7 tw-text-m tw-gap-2",
+                    isColorLight(color) ? "tw-text-black" : "tw-text-white",
+                ])}
+                style={{ backgroundColor }}
                 data-test-id="color-preview"
             >
                 {colorName && <span className="tw-font-bold">{colorName}</span>}

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -36,7 +36,7 @@ export const ColorPicker: FC<ColorPickerProps> = ({
     currentFormat = ColorFormat.Hex,
 }) => {
     const [colorType, setColorType] = useState(ColorType.Brand);
-    const [color, setColor] = useState(currentColor);
+    const [color, setColor] = useState<Color>(currentColor);
 
     useEffect(() => {
         setColor({ ...currentColor, a: currentColor.a || 1 });

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -78,9 +78,9 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                 </div>
                 <div className="tw-relative tw-w-6 tw-overflow-hidden tw-rounded">
                     <Alpha
-                        rgb={rgb}
-                        hsl={hsl}
-                        hsv={hsv}
+                        rgb={parsedColor.toRgb()}
+                        hsl={parsedColor.toHsl()}
+                        hsv={parsedColor.toHsv()}
                         direction="vertical"
                         pointer={() => (
                             <div className="tw-w-[18px] tw-flex tw-justify-center">
@@ -102,7 +102,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                 </div>
                 {currentFormat === ColorFormat.Hex ? (
                     <div className="tw-flex-1">
-                        <ColorInput
+                        {/* <ColorInput
                             value={hexInput}
                             decorator="#"
                             size={6}
@@ -111,7 +111,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             }}
                             onEnterPressed={handleHexChange}
                             onBlur={handleHexChange}
-                        />
+                        /> */}
                     </div>
                 ) : (
                     <>

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -4,14 +4,13 @@
 
 import { Dropdown } from "@components/Dropdown/Dropdown";
 import { TextInputType } from "@components/TextInput/TextInput";
-import { toColor, transformColor } from "@utilities/colors";
 import { debounce } from "@utilities/debounce";
 import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useState } from "react";
 // @ts-ignore
 import { Alpha, Hue, Saturation } from "react-color/lib/components/common";
 // @ts-ignore
-import { isValidHex, toState } from "react-color/lib/helpers/color";
+import tinycolor from "tinycolor2";
 import { ColorFormat } from "../../types/colors";
 import { ColorInput } from "./ColorInput";
 import { ColorPickerProps } from "./ColorPicker";
@@ -32,33 +31,36 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
     onSelect,
 }) => {
     const colorFormats = Object.values(ColorFormat).map((id) => ({ id, title: id.toLocaleUpperCase() }));
-    const [{ hsl, hsv, rgb, hex }, setColor] = useState(transformColor(currentColor));
+    const [color, setColor] = useState(currentColor);
+    const parsedColor = tinycolor(color);
+    const { r, g, b, a } = parsedColor.toRgb();
 
     useEffect(() => {
-        setColor(transformColor(currentColor));
+        setColor(currentColor);
     }, [currentColor]);
 
-    const [hexInput, setHexInput] = useState(hex.substring(1));
+    // const [hexInput, setHexInput] = useState(tinycolor(currentColor).toHex);
 
-    useEffect(() => {
-        setHexInput(hex.substring(1));
-    }, [hex]);
+    // useEffect(() => {
+    //     setHexInput(tinycolor(color).toHex);
+    // }, [color]);
 
-    const handleHexChange = () => {
-        if (isValidHex(hexInput)) {
-            onSelect(toColor(currentColor, { hex: hexInput }));
-        }
-    };
+    // const handleHexChange = () => {
+    //     console.log("save hex input, brudi");
+    //     // if (isValidHex(hexInput)) {
+    //     //     onSelect(toColor(currentColor, { hex: hexInput }));
+    //     // }
+    // };
 
     return (
         <div className="tw-flex tw-flex-col tw-gap-5" data-test-id="custom-color-picker">
             <div className="tw-flex tw-gap-2 tw-w-full tw-h-[200px]">
                 <div className="tw-relative tw-flex-grow tw-overflow-hidden tw-rounded">
                     <Saturation
-                        hsl={hsl}
-                        hsv={hsv}
+                        hsl={parsedColor.toHsl()}
+                        hsv={parsedColor.toHsv()}
                         pointer={() => <ColorPointer />}
-                        onChange={debounce((color) => onSelect(toColor(currentColor, { hex: toState(color).hex })))}
+                        onChange={debounce((color) => onSelect(color))}
                     />
                 </div>
                 <div className="tw-relative tw-w-6 tw-overflow-hidden tw-rounded">
@@ -68,24 +70,24 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                                 <ColorPointer offset={false} />
                             </div>
                         )}
-                        hsl={hsl}
+                        hsl={parsedColor.toHsl()}
                         direction="vertical"
-                        onChange={debounce((color) => onSelect(toColor(currentColor, { hex: toState(color).hex })))}
+                        onChange={debounce((color) => onSelect(color))}
                     />
                 </div>
                 <div className="tw-relative tw-w-6 tw-overflow-hidden tw-rounded">
                     <Alpha
-                        rgb={rgb}
-                        hsl={hsl}
-                        hsv={hsv}
+                        rgb={parsedColor.toRgb()}
+                        hsl={parsedColor.toHsl()}
+                        hsv={parsedColor.toHsv()}
                         direction="vertical"
                         pointer={() => (
                             <div className="tw-w-[18px] tw-flex tw-justify-center">
                                 <ColorPointer offset={false} />
                             </div>
                         )}
-                        style={{ pointer: { top: `${rgb.a * 100}%` } }}
-                        onChange={debounce(({ a }) => onSelect(toColor(currentColor, { rgba: { a } })))}
+                        style={{ pointer: { top: `${a * 100}%` } }}
+                        onChange={debounce((color) => onSelect(color))}
                     />
                 </div>
             </div>
@@ -99,7 +101,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                 </div>
                 {currentFormat === ColorFormat.Hex ? (
                     <div className="tw-flex-1">
-                        <ColorInput
+                        {/* <ColorInput
                             value={hexInput}
                             decorator="#"
                             size={6}
@@ -108,7 +110,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             }}
                             onEnterPressed={handleHexChange}
                             onBlur={handleHexChange}
-                        />
+                        /> */}
                     </div>
                 ) : (
                     <>
@@ -117,27 +119,27 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             max={255}
                             size={3}
                             type={TextInputType.Number}
-                            value={rgb.r.toString()}
+                            value={String(r)}
                             decorator="R"
-                            onChange={(r) => onSelect(toColor(currentColor, { rgba: { r } }))}
+                            //onChange={(r) => onSelect(toColor(currentColor, { rgba: { r } }))}
                         />
                         <ColorInput
                             min={0}
                             max={255}
                             size={3}
                             type={TextInputType.Number}
-                            value={rgb.g.toString()}
+                            value={String(g)}
                             decorator="G"
-                            onChange={(g) => onSelect(toColor(currentColor, { rgba: { g } }))}
+                            //onChange={(g) => onSelect(toColor(currentColor, { rgba: { g } }))}
                         />
                         <ColorInput
                             min={0}
                             max={255}
                             size={3}
                             type={TextInputType.Number}
-                            value={rgb.b.toString()}
+                            value={String(b)}
                             decorator="B"
-                            onChange={(b) => onSelect(toColor(currentColor, { rgba: { b } }))}
+                            //onChange={(b) => onSelect(toColor(currentColor, { rgba: { b } }))}
                         />
                     </>
                 )}
@@ -146,12 +148,12 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                     max={100}
                     size={3}
                     type={TextInputType.Number}
-                    value={`${Math.round(rgb.a * 100)}`}
+                    value={String(a * 100)}
                     decorator="%"
-                    onChange={(value) => {
-                        const a = parseInt(value || "0", 10) / 100;
-                        onSelect(toColor(currentColor, { rgba: { a } }));
-                    }}
+                    // onChange={(value) => {
+                    //     const a = parseInt(value || "0", 10) / 100;
+                    //     onSelect(toColor(currentColor, { rgba: { a } }));
+                    // }}
                 />
             </div>
         </div>

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -32,21 +32,19 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
     const colorFormats = Object.values(ColorFormat).map((id) => ({ id, title: id.toLocaleUpperCase() }));
     const [color, setColor] = useState<Color>(currentColor);
     const parsedColor = tinycolor(color);
-    const { r, g, b, a } = parsedColor.toRgb();
-
-    useEffect(() => {
-        setColor(currentColor);
-    }, [currentColor]);
-
+    const rgb = parsedColor.toRgb();
+    const hsl = parsedColor.toHsl();
+    const hsv = parsedColor.toHsv();
+    const { r, g, b, a } = rgb;
     const [hexInput, setHexInput] = useState(parsedColor.toHex());
 
     useEffect(() => {
+        setColor(currentColor);
         setHexInput(parsedColor.toHex());
-    }, [color]);
+    }, [currentColor]);
 
     const handleHexChange = () => {
         const parsedHex = tinycolor(hexInput);
-        parsedHex.isValid();
         if (parsedHex.isValid()) {
             onSelect(parsedHex.toRgb());
         }
@@ -57,9 +55,9 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
             <div className="tw-flex tw-gap-2 tw-w-full tw-h-[200px]">
                 <div className="tw-relative tw-flex-grow tw-overflow-hidden tw-rounded">
                     <Saturation
-                        rgb={parsedColor.toRgb()}
-                        hsl={parsedColor.toHsl()}
-                        hsv={parsedColor.toHsv()}
+                        rgb={rgb}
+                        hsl={hsl}
+                        hsv={hsv}
                         pointer={() => <ColorPointer />}
                         onChange={debounce((color) => onSelect(tinycolor(color).toRgb()))}
                     />
@@ -71,18 +69,18 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                                 <ColorPointer offset={false} />
                             </div>
                         )}
-                        rgb={parsedColor.toRgb()}
-                        hsl={parsedColor.toHsl()}
-                        hsv={parsedColor.toHsv()}
+                        rgb={rgb}
+                        hsl={hsl}
+                        hsv={hsv}
                         direction="vertical"
                         onChange={debounce((color) => onSelect(tinycolor(color).toRgb()))}
                     />
                 </div>
                 <div className="tw-relative tw-w-6 tw-overflow-hidden tw-rounded">
                     <Alpha
-                        rgb={parsedColor.toRgb()}
-                        hsl={parsedColor.toHsl()}
-                        hsv={parsedColor.toHsv()}
+                        rgb={rgb}
+                        hsl={hsl}
+                        hsv={hsv}
                         direction="vertical"
                         pointer={() => (
                             <div className="tw-w-[18px] tw-flex tw-justify-center">

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -9,9 +9,8 @@ import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useState } from "react";
 // @ts-ignore
 import { Alpha, Hue, Saturation } from "react-color/lib/components/common";
-// @ts-ignore
 import tinycolor from "tinycolor2";
-import { ColorFormat } from "../../types/colors";
+import { Color, ColorFormat } from "../../types/colors";
 import { ColorInput } from "./ColorInput";
 import { ColorPickerProps } from "./ColorPicker";
 
@@ -31,7 +30,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
     onSelect,
 }) => {
     const colorFormats = Object.values(ColorFormat).map((id) => ({ id, title: id.toLocaleUpperCase() }));
-    const [color, setColor] = useState(currentColor);
+    const [color, setColor] = useState<Color>(currentColor);
     const parsedColor = tinycolor(color);
     const { r, g, b, a } = parsedColor.toRgb();
 
@@ -39,18 +38,19 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
         setColor(currentColor);
     }, [currentColor]);
 
-    // const [hexInput, setHexInput] = useState(tinycolor(currentColor).toHex);
+    const [hexInput, setHexInput] = useState(parsedColor.toHex());
 
-    // useEffect(() => {
-    //     setHexInput(tinycolor(color).toHex);
-    // }, [color]);
+    useEffect(() => {
+        setHexInput(parsedColor.toHex());
+    }, [color]);
 
-    // const handleHexChange = () => {
-    //     console.log("save hex input, brudi");
-    //     // if (isValidHex(hexInput)) {
-    //     //     onSelect(toColor(currentColor, { hex: hexInput }));
-    //     // }
-    // };
+    const handleHexChange = () => {
+        const parsedHex = tinycolor(hexInput);
+        parsedHex.isValid();
+        if (parsedHex.isValid()) {
+            onSelect(parsedHex.toRgb());
+        }
+    };
 
     return (
         <div className="tw-flex tw-flex-col tw-gap-5" data-test-id="custom-color-picker">
@@ -101,16 +101,16 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                 </div>
                 {currentFormat === ColorFormat.Hex ? (
                     <div className="tw-flex-1">
-                        {/* <ColorInput
+                        <ColorInput
                             value={hexInput}
                             decorator="#"
                             size={6}
-                            onChange={(hex) => {
-                                setHexInput(hex);
+                            onChange={(input) => {
+                                setHexInput(input);
                             }}
                             onEnterPressed={handleHexChange}
                             onBlur={handleHexChange}
-                        /> */}
+                        />
                     </div>
                 ) : (
                     <>
@@ -119,27 +119,27 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             max={255}
                             size={3}
                             type={TextInputType.Number}
-                            value={String(r)}
+                            value={r.toString()}
                             decorator="R"
-                            //onChange={(r) => onSelect(toColor(currentColor, { rgba: { r } }))}
+                            onChange={(r) => onSelect({ ...color, r: parseInt(r) })}
                         />
                         <ColorInput
                             min={0}
                             max={255}
                             size={3}
                             type={TextInputType.Number}
-                            value={String(g)}
+                            value={g.toString()}
                             decorator="G"
-                            //onChange={(g) => onSelect(toColor(currentColor, { rgba: { g } }))}
+                            onChange={(g) => onSelect({ ...color, g: parseInt(g) })}
                         />
                         <ColorInput
                             min={0}
                             max={255}
                             size={3}
                             type={TextInputType.Number}
-                            value={String(b)}
+                            value={b.toString()}
                             decorator="B"
-                            //onChange={(b) => onSelect(toColor(currentColor, { rgba: { b } }))}
+                            onChange={(b) => onSelect({ ...color, b: parseInt(b) })}
                         />
                     </>
                 )}
@@ -148,12 +148,12 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                     max={100}
                     size={3}
                     type={TextInputType.Number}
-                    value={String(a * 100)}
+                    value={Math.trunc(a * 100).toString()}
                     decorator="%"
-                    // onChange={(value) => {
-                    //     const a = parseInt(value || "0", 10) / 100;
-                    //     onSelect(toColor(currentColor, { rgba: { a } }));
-                    // }}
+                    onChange={(value) => {
+                        const a = parseInt(value || "0", 10) / 100;
+                        onSelect({ ...color, a });
+                    }}
                 />
             </div>
         </div>

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -102,7 +102,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                 </div>
                 {currentFormat === ColorFormat.Hex ? (
                     <div className="tw-flex-1">
-                        {/* <ColorInput
+                        <ColorInput
                             value={hexInput}
                             decorator="#"
                             size={6}
@@ -111,7 +111,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             }}
                             onEnterPressed={handleHexChange}
                             onBlur={handleHexChange}
-                        /> */}
+                        />
                     </div>
                 ) : (
                     <>

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -78,9 +78,9 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                 </div>
                 <div className="tw-relative tw-w-6 tw-overflow-hidden tw-rounded">
                     <Alpha
-                        rgb={parsedColor.toRgb()}
-                        hsl={parsedColor.toHsl()}
-                        hsv={parsedColor.toHsv()}
+                        rgb={rgb}
+                        hsl={hsl}
+                        hsv={hsv}
                         direction="vertical"
                         pointer={() => (
                             <div className="tw-w-[18px] tw-flex tw-justify-center">

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -40,7 +40,6 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
 
     useEffect(() => {
         setColor(currentColor);
-        setHexInput(parsedColor.toHex());
     }, [currentColor]);
 
     const handleHexChange = () => {
@@ -49,6 +48,10 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
             onSelect(parsedHex.toRgb());
         }
     };
+
+    useEffect(() => {
+        setHexInput(parsedColor.toHex());
+    }, [color]);
 
     return (
         <div className="tw-flex tw-flex-col tw-gap-5" data-test-id="custom-color-picker">

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -106,9 +106,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             value={hexInput}
                             decorator="#"
                             size={6}
-                            onChange={(input) => {
-                                setHexInput(input);
-                            }}
+                            onChange={setHexInput}
                             onEnterPressed={handleHexChange}
                             onBlur={handleHexChange}
                         />

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -57,10 +57,11 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
             <div className="tw-flex tw-gap-2 tw-w-full tw-h-[200px]">
                 <div className="tw-relative tw-flex-grow tw-overflow-hidden tw-rounded">
                     <Saturation
+                        rgb={parsedColor.toRgb()}
                         hsl={parsedColor.toHsl()}
                         hsv={parsedColor.toHsv()}
                         pointer={() => <ColorPointer />}
-                        onChange={debounce((color) => onSelect(color))}
+                        onChange={debounce((color) => onSelect(tinycolor(color).toRgb()))}
                     />
                 </div>
                 <div className="tw-relative tw-w-6 tw-overflow-hidden tw-rounded">
@@ -70,9 +71,11 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                                 <ColorPointer offset={false} />
                             </div>
                         )}
+                        rgb={parsedColor.toRgb()}
                         hsl={parsedColor.toHsl()}
+                        hsv={parsedColor.toHsv()}
                         direction="vertical"
-                        onChange={debounce((color) => onSelect(color))}
+                        onChange={debounce((color) => onSelect(tinycolor(color).toRgb()))}
                     />
                 </div>
                 <div className="tw-relative tw-w-6 tw-overflow-hidden tw-rounded">
@@ -87,7 +90,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             </div>
                         )}
                         style={{ pointer: { top: `${a * 100}%` } }}
-                        onChange={debounce((color) => onSelect(color))}
+                        onChange={debounce((color) => onSelect(tinycolor(color).toRgb()))}
                     />
                 </div>
             </div>

--- a/src/components/ColorPicker/example-palettes.ts
+++ b/src/components/ColorPicker/example-palettes.ts
@@ -1,0 +1,40 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import tinycolor from "tinycolor2";
+import { Color, Palette } from "../../types/colors";
+
+const generatePalette = (color: string, amount: number): Color[] => {
+    const sourceColor = tinycolor(color);
+    const palette = [...new Array(amount)].map((_, index) => {
+        const name = (90 - index * 10).toString();
+        const lightColor = sourceColor.lighten(index * 3).toRgb();
+        return {
+            ...lightColor,
+            name,
+        };
+    });
+    return palette;
+};
+
+export const EXAMPLE_PALETTES: Palette[] = [
+    {
+        id: "red",
+        title: "Red",
+        source: "#992136",
+    },
+    {
+        id: "green",
+        title: "Green",
+        source: "#006452",
+    },
+    {
+        id: "yellow",
+        title: "Yellow",
+        source: "#cc9000",
+    },
+].map((palette) => {
+    return {
+        ...palette,
+        colors: generatePalette(palette.source, 6),
+    };
+});

--- a/src/types/colors.ts
+++ b/src/types/colors.ts
@@ -8,15 +8,10 @@ export type ColorState = {
 };
 
 export type Color = {
-    rgba?: { r: number; g: number; b: number; a: number };
-    hex: string;
-    alpha?: number;
-    name?: string;
-};
-
-export type DiffColor = {
-    hex?: string;
-    rgba?: { r?: number | string; g?: number | string; b?: number | string; a?: number };
+    r: number;
+    g: number;
+    b: number;
+    a?: number;
     name?: string;
 };
 

--- a/src/types/colors.ts
+++ b/src/types/colors.ts
@@ -1,12 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-export type ColorState = {
-    rgb: { r: number; g: number; b: number; a: number };
-    hsl: { h: number; s: number; l: number; a: number };
-    hsv: { h: number; s: number; v: number; a: number };
-    hex: string;
-};
-
 export type Color = {
     r: number;
     g: number;

--- a/src/utilities/colors.ts
+++ b/src/utilities/colors.ts
@@ -26,12 +26,9 @@ const generatePalette = (color: string, amount: number): Color[] => {
     const sourceColor = tinycolor(color);
     const palette = [...new Array(amount)].map((_, index) => {
         const name = (90 - index * 10).toString();
-        const { r, g, b, a } = sourceColor.lighten(index * 3).toRgb();
+        const lightColor = sourceColor.lighten(index * 3).toRgb();
         return {
-            r,
-            g,
-            b,
-            a,
+            ...lightColor,
             name,
         };
     });

--- a/src/utilities/colors.ts
+++ b/src/utilities/colors.ts
@@ -1,7 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-ignore
 import tinycolor from "tinycolor2";
 import { Color, ColorFormat, Palette } from "../types/colors";
 
@@ -24,82 +22,41 @@ export const isColorLight = (color: Color): boolean => {
     return parsedColor.isLight() || parsedColor.getAlpha() < 0.25;
 };
 
+const generatePalette = (color: string, amount: number): Color[] => {
+    const sourceColor = tinycolor(color);
+    const palette = [...new Array(amount)].map((_, index) => {
+        const name = (90 - index * 10).toString();
+        const { r, g, b, a } = sourceColor.lighten(index * 3).toRgb();
+        return {
+            r,
+            g,
+            b,
+            a,
+            name,
+        };
+    });
+    return palette;
+};
+
 export const EXAMPLE_PALETTES: Palette[] = [
     {
         id: "red",
-        source: "#992136",
         title: "Red",
+        source: "#992136",
     },
     {
         id: "green",
-        source: "#006452",
         title: "Green",
+        source: "#006452",
     },
     {
         id: "yellow",
-        source: "#cc9000",
         title: "Yellow",
+        source: "#cc9000",
     },
 ].map((palette) => {
-    const sourceColor = tinycolor(palette.source);
     return {
         ...palette,
-        colors: [...new Array(6)].map((_, index) => {
-            const color = sourceColor.lighten(5).toRgb();
-            let name = "";
-            let r = 225,
-                g = 255,
-                b = 255,
-                a = 1;
-
-            switch (index) {
-                case 0:
-                    r = color.r;
-                    g = color.g;
-                    b = color.b;
-                    a = color.a;
-                    name = "90";
-                    break;
-                case 1:
-                    r = color.r;
-                    g = color.g;
-                    b = color.b;
-                    a = color.a;
-                    name = "80";
-                    break;
-                case 2:
-                    r = color.r;
-                    g = color.g;
-                    b = color.b;
-                    a = color.a;
-                    name = "70";
-                    break;
-                case 3:
-                    r = color.r;
-                    g = color.g;
-                    b = color.b;
-                    a = color.a;
-                    name = "60";
-                    break;
-                case 4:
-                    r = color.r;
-                    g = color.g;
-                    b = color.b;
-                    a = color.a;
-                    name = "50";
-                    break;
-                case 5:
-                    r = color.r;
-                    g = color.g;
-                    b = color.b;
-                    a = color.a;
-                    name = "40";
-                    break;
-                default:
-                    break;
-            }
-
-            return { r, g, b, a, name };
-        }),
+        colors: generatePalette(palette.source, 6),
     };
 });

--- a/src/utilities/colors.ts
+++ b/src/utilities/colors.ts
@@ -13,7 +13,7 @@ export const getColorDisplayValue = (color: Color, format: ColorFormat, showAlph
             return parsedColor.toRgbString();
         case ColorFormat.Hex:
             const hex = parsedColor.toHexString();
-            return showAlpha && color.a && color.a < 1 ? `${hex} ${parsedColor.getAlpha()}` : hex;
+            return showAlpha && color.a && color.a < 1 ? `${hex} ${Math.trunc(parsedColor.getAlpha() * 100)}%` : hex;
         default:
             return parsedColor.toHexString();
     }

--- a/src/utilities/colors.ts
+++ b/src/utilities/colors.ts
@@ -2,32 +2,8 @@
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
-import { toState } from "react-color/lib/helpers/color";
 import tinycolor from "tinycolor2";
-import { Color, ColorFormat, ColorState, Palette } from "../types/colors";
-
-export const getValidRgbColorValue = (input: string): number => {
-    const value = parseInt(input || "0", 10);
-
-    if (value > 255) {
-        return 255;
-    }
-
-    return value < 0 ? 0 : value;
-};
-
-export const transformColor = (color: Color): ColorState => toState({ ...toState(color).rgb, a: color.alpha });
-
-export const toColor = (current: Color, { name, ...diff }: DiffColor): Color => {
-    const a = diff.rgba?.a || current.rgba?.a || current.alpha || 0;
-    const alpha = a > 1 ? 1 : a;
-    const rgb = { ...current.rgba, ...toState({ hex: diff.hex || current.hex }).rgb, ...diff.rgba };
-    const [r, g, b] = [rgb.r, rgb.g, rgb.b].map(getValidRgbColorValue);
-    const rgba = { r, g, b, a: alpha };
-    const hex = toState(rgba).hex;
-
-    return { name, rgba, alpha, hex };
-};
+import { Color, ColorFormat, Palette } from "../types/colors";
 
 export const getColorDisplayValue = (color: Color, format: ColorFormat, showAlpha = true): string => {
     const parsedColor = tinycolor(color);
@@ -46,47 +22,79 @@ export const getColorDisplayValue = (color: Color, format: ColorFormat, showAlph
 export const EXAMPLE_PALETTES: Palette[] = [
     {
         id: "red",
+        source: "#992136",
         title: "Red",
-        colors: ["#992136", "#cc2c48", "#ff375a", "#ff8066", "#e1c4be", "#f0e1de"],
     },
     {
         id: "green",
+        source: "#006452",
         title: "Green",
-        colors: ["#006452", "#00866e", "#00c8a5", "#80dbb7", "#bee1d4", "#def0e9"],
     },
     {
         id: "yellow",
+        source: "#cc9000",
         title: "Yellow",
-        colors: ["#cc9000", "#e6a200", "#ffb400", "#eec779", "#e1d4be", "#f0e9de"],
     },
-].map((palette) => ({
-    ...palette,
-    colors: palette.colors.map((hex, index) => {
-        let name = "";
+].map((palette) => {
+    const sourceColor = tinycolor(palette.source);
+    return {
+        ...palette,
+        colors: [...new Array(6)].map((_, index) => {
+            const color = sourceColor.lighten(5).toRgb();
+            let name = "";
+            let r = 225,
+                g = 255,
+                b = 255,
+                a = 1;
 
-        switch (index) {
-            case 0:
-                name = "90";
-                break;
-            case 1:
-                name = "70";
-                break;
-            case 2:
-                name = "60";
-                break;
-            case 3:
-                name = "50";
-                break;
-            case 4:
-                name = "40";
-                break;
-            case 5:
-                name = "20";
-                break;
-            default:
-                break;
-        }
+            switch (index) {
+                case 0:
+                    r = color.r;
+                    g = color.g;
+                    b = color.b;
+                    a = color.a;
+                    name = "90";
+                    break;
+                case 1:
+                    r = color.r;
+                    g = color.g;
+                    b = color.b;
+                    a = color.a;
+                    name = "80";
+                    break;
+                case 2:
+                    r = color.r;
+                    g = color.g;
+                    b = color.b;
+                    a = color.a;
+                    name = "70";
+                    break;
+                case 3:
+                    r = color.r;
+                    g = color.g;
+                    b = color.b;
+                    a = color.a;
+                    name = "60";
+                    break;
+                case 4:
+                    r = color.r;
+                    g = color.g;
+                    b = color.b;
+                    a = color.a;
+                    name = "50";
+                    break;
+                case 5:
+                    r = color.r;
+                    g = color.g;
+                    b = color.b;
+                    a = color.a;
+                    name = "40";
+                    break;
+                default:
+                    break;
+            }
 
-        return { hex, name, alpha: 1 };
-    }),
-}));
+            return { r, g, b, a, name };
+        }),
+    };
+});

--- a/src/utilities/colors.ts
+++ b/src/utilities/colors.ts
@@ -19,6 +19,11 @@ export const getColorDisplayValue = (color: Color, format: ColorFormat, showAlph
     }
 };
 
+export const isColorLight = (color: Color): boolean => {
+    const parsedColor = tinycolor(color);
+    return parsedColor.isLight() || parsedColor.getAlpha() < 0.25;
+};
+
 export const EXAMPLE_PALETTES: Palette[] = [
     {
         id: "red",

--- a/src/utilities/colors.ts
+++ b/src/utilities/colors.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import tinycolor from "tinycolor2";
-import { Color, ColorFormat, Palette } from "../types/colors";
+import { Color, ColorFormat } from "../types/colors";
 
 export const getColorDisplayValue = (color: Color, format: ColorFormat, showAlpha = true): string => {
     const parsedColor = tinycolor(color);
@@ -21,39 +21,3 @@ export const isColorLight = (color: Color): boolean => {
     const parsedColor = tinycolor(color);
     return parsedColor.isLight() || parsedColor.getAlpha() < 0.25;
 };
-
-const generatePalette = (color: string, amount: number): Color[] => {
-    const sourceColor = tinycolor(color);
-    const palette = [...new Array(amount)].map((_, index) => {
-        const name = (90 - index * 10).toString();
-        const lightColor = sourceColor.lighten(index * 3).toRgb();
-        return {
-            ...lightColor,
-            name,
-        };
-    });
-    return palette;
-};
-
-export const EXAMPLE_PALETTES: Palette[] = [
-    {
-        id: "red",
-        title: "Red",
-        source: "#992136",
-    },
-    {
-        id: "green",
-        title: "Green",
-        source: "#006452",
-    },
-    {
-        id: "yellow",
-        title: "Yellow",
-        source: "#cc9000",
-    },
-].map((palette) => {
-    return {
-        ...palette,
-        colors: generatePalette(palette.source, 6),
-    };
-});

--- a/src/utilities/colors.ts
+++ b/src/utilities/colors.ts
@@ -3,7 +3,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import { toState } from "react-color/lib/helpers/color";
-import { Color, ColorFormat, ColorState, DiffColor, Palette } from "../types/colors";
+import tinycolor from "tinycolor2";
+import { Color, ColorFormat, ColorState, Palette } from "../types/colors";
 
 export const getValidRgbColorValue = (input: string): number => {
     const value = parseInt(input || "0", 10);
@@ -28,26 +29,17 @@ export const toColor = (current: Color, { name, ...diff }: DiffColor): Color => 
     return { name, rgba, alpha, hex };
 };
 
-export const getBackgroundColor = (color: Color): string => {
-    const { rgba, hex } = color;
-    if (rgba) {
-        return `rgba(${Object.values(rgba).join(", ")})`;
-    }
-    return hex;
-};
-
-export const getAlphaPercent = (alpha: number): string => `${Math.round(alpha * 100)}%`;
-
 export const getColorDisplayValue = (color: Color, format: ColorFormat, showAlpha = true): string => {
-    const { hex, rgba, alpha } = color;
+    const parsedColor = tinycolor(color);
 
     switch (format) {
         case ColorFormat.Rgba:
-            return rgba ? `rgba(${Object.values(rgba).join(", ")})` : hex;
+            return parsedColor.toRgbString();
         case ColorFormat.Hex:
-            return showAlpha && alpha && alpha < 1 ? `${hex} ${getAlphaPercent(alpha)}` : hex;
+            const hex = parsedColor.toHexString();
+            return showAlpha && color.a && color.a < 1 ? `${hex} ${parsedColor.getAlpha()}` : hex;
         default:
-            return hex;
+            return parsedColor.toHexString();
     }
 };
 


### PR DESCRIPTION
This PR simplifies the color data structure as described in the following ticket, to avoid having colors in multiple color spaces (rgb, hex etc.): https://app.clickup.com/t/22b6p20

It also removes most of the utility methods in `src/utilities/colors.ts` and uses the `tinycolor2` library for color manipulation and conversion instead.