### PR TITLE
fix: Fixate arcade-tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@frontify/arcade",
             "version": "1.0.0",
             "dependencies": {
-                "@frontify/arcade-tokens": "^1.0.0-next.24",
+                "@frontify/arcade-tokens": "1.0.0-next.27",
                 "@react-aria/accordion": "^3.0.0-alpha.2",
                 "@react-aria/aria-modal-polyfill": "^3.4.0",
                 "@react-aria/breadcrumbs": "^3.1.5",
@@ -2486,9 +2486,9 @@
             }
         },
         "node_modules/@frontify/arcade-tokens": {
-            "version": "1.0.0-next.25",
-            "resolved": "https://registry.npmjs.org/@frontify/arcade-tokens/-/arcade-tokens-1.0.0-next.25.tgz",
-            "integrity": "sha512-tOEfVQ6aUoZHmjB63d9PnSJDI6AHMWfqODOZ1Dw4zSjrXEXDI3vUyNR6O0bA9QJqRK1YRx7s31B/vJdg089fMQ==",
+            "version": "1.0.0-next.27",
+            "resolved": "https://registry.npmjs.org/@frontify/arcade-tokens/-/arcade-tokens-1.0.0-next.27.tgz",
+            "integrity": "sha512-ANRzvKJsv5bmCL1H0q7dSuf/5+09YoSdkVIxxQxr38vHg9LVcvOLcZvQfxRHC1gd8kKODZybNhCcrawUQryLTA==",
             "dependencies": {
                 "tailwindcss": "^2.2.19"
             }
@@ -27461,9 +27461,9 @@
             }
         },
         "@frontify/arcade-tokens": {
-            "version": "1.0.0-next.25",
-            "resolved": "https://registry.npmjs.org/@frontify/arcade-tokens/-/arcade-tokens-1.0.0-next.25.tgz",
-            "integrity": "sha512-tOEfVQ6aUoZHmjB63d9PnSJDI6AHMWfqODOZ1Dw4zSjrXEXDI3vUyNR6O0bA9QJqRK1YRx7s31B/vJdg089fMQ==",
+            "version": "1.0.0-next.27",
+            "resolved": "https://registry.npmjs.org/@frontify/arcade-tokens/-/arcade-tokens-1.0.0-next.27.tgz",
+            "integrity": "sha512-ANRzvKJsv5bmCL1H0q7dSuf/5+09YoSdkVIxxQxr38vHg9LVcvOLcZvQfxRHC1gd8kKODZybNhCcrawUQryLTA==",
             "requires": {
                 "tailwindcss": "^2.2.19"
             }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "react-dom": "^17.0.2"
     },
     "dependencies": {
-        "@frontify/arcade-tokens": "^1.0.0-next.24",
+        "@frontify/arcade-tokens": "1.0.0-next.27",
         "@react-aria/accordion": "^3.0.0-alpha.2",
         "@react-aria/aria-modal-polyfill": "^3.4.0",
         "@react-aria/breadcrumbs": "^3.1.5",


### PR DESCRIPTION
Fixate arcade-tokens to 1.0.0-next.27, because the next release will be tailwind-3 compatible only.