### PR TITLE
fix(color-picker-flyout): slider animation when inside accordion

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -15,6 +15,12 @@ import { IconSize } from "@foundation/Icon/IconSize";
 import { action } from "@storybook/addon-actions";
 import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
+import { Color } from "../../types/colors";
+import {
+    ColorPickerFlyout as ColorPickerFlyoutComponent,
+    ColorPickerFlyoutProps,
+} from "../ColorInputFlyout/ColorPickerFlyout";
+import { EXAMPLE_PALETTES } from "../ColorPicker/example-palettes";
 import { Accordion as AccordionComponent, AccordionItem, AccordionProps } from "./Accordion";
 
 // eslint-disable-next-line import/no-default-export
@@ -146,6 +152,29 @@ export const WithAdvancedFormControls: Story<AccordionProps> = () => {
                         ]}
                     />
                 </FormControl>
+            </AccordionItem>
+        </AccordionComponent>
+    );
+};
+
+export const WithColorPickerFlyout: Story<ColorPickerFlyoutProps> = ({
+    disabled = false,
+    currentColor = { r: 0, g: 146, b: 120 },
+}) => {
+    const [temporaryColor, setTemporaryColor] = useState<Color | null>(currentColor);
+    const [selectedColor, setSelectedColor] = useState<Color | null>(null);
+
+    return (
+        <AccordionComponent>
+            <AccordionItem header={{ children: "Color Picker Flyout", type: FieldsetHeaderType.Accordion }}>
+                <ColorPickerFlyoutComponent
+                    disabled={disabled}
+                    currentColor={temporaryColor}
+                    onClick={() => setSelectedColor(temporaryColor)}
+                    onClose={() => setTemporaryColor(selectedColor)}
+                    onSelect={(color) => setTemporaryColor(color)}
+                    palettes={EXAMPLE_PALETTES}
+                />
             </AccordionItem>
         </AccordionComponent>
     );

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -9,7 +9,7 @@ import { VisuallyHidden } from "@react-aria/visually-hidden";
 import { RadioGroupState, useRadioGroupState } from "@react-stately/radio";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
 import { merge } from "@utilities/merge";
-import { AnimateSharedLayout, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import React, { FC, ReactElement, useMemo, useRef } from "react";
 
 export type IconItem = {
@@ -66,7 +66,7 @@ const SliderItem = (props: SliderItemProps) => {
     };
 
     return (
-        <li key={item.id} className="tw-relative">
+        <motion.li layout key={item.id} className="tw-relative">
             {isActive && (
                 <motion.div
                     key={id}
@@ -111,7 +111,7 @@ const SliderItem = (props: SliderItemProps) => {
                     {isIconItem(item) ? <span aria-label={item.ariaLabel}>{item.icon}</span> : item.value.toString()}
                 </span>
             </div>
-        </li>
+        </motion.li>
     );
 };
 
@@ -145,7 +145,7 @@ export const Slider: FC<SliderProps> = ({
             data-test-id="slider"
             className="tw-relative tw-h-9 tw-w-full tw-grid tw-grid-flow-col tw-auto-cols-fr tw-justify-evenly tw-p-0 tw-border tw-border-black-20 tw-m-0 tw-bg-black-0 tw-rounded tw-font-sans tw-text-s tw-list-none tw-select-none"
         >
-            <AnimateSharedLayout>{itemElements}</AnimateSharedLayout>
+            {itemElements}
         </ul>
     );
 };


### PR DESCRIPTION
Regards this clickup ticket: https://app.clickup.com/t/23t26zw

Removed `AnimateSharedLayout ` as it was removed as of Framer Motion 5. Used `motion.li` to correctly detect changes in the layout and animate it instead.