### PR TITLE
Feature: Support Flyout content width

### DIFF
--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -47,6 +47,7 @@ export type FlyoutProps = PropsWithChildren<{
     decorator?: ReactNode;
     badges?: BadgeProps[];
     hug?: boolean;
+    fitContent?: boolean;
     isOpen?: boolean;
     onOpenChange: (isOpen: boolean) => void;
     fixedHeader?: ReactNode;
@@ -77,6 +78,7 @@ const OverlayComponent: ForwardRefRenderFunction<HTMLDivElement, OverlayProps> =
         scrollRef,
         legacyFooter,
         fixedHeader,
+        fitContent,
     },
     ref,
 ) => {
@@ -88,7 +90,10 @@ const OverlayComponent: ForwardRefRenderFunction<HTMLDivElement, OverlayProps> =
         <div
             {...mergeProps(overlayProps, dialogProps, modalProps, positionProps, overlayTriggerProps)}
             ref={ref}
-            className="tw-max-h-full tw-flex tw-shadow-mid tw-min-w-[400px] tw-outline-none"
+            className={merge([
+                "tw-max-h-full tw-flex tw-shadow-mid tw-outline-none",
+                fitContent ? "tw-min-w-0" : "tw-min-w-[400px]",
+            ])}
         >
             <div className="tw-flex tw-flex-col tw-flex-auto tw-min-h-0">
                 {fixedHeader}
@@ -150,6 +155,7 @@ export const Flyout: FC<FlyoutProps> = ({
     title = "",
     badges = [],
     hug = true,
+    fitContent = false,
     legacyFooter = true,
     fixedHeader,
 }) => {
@@ -224,6 +230,7 @@ export const Flyout: FC<FlyoutProps> = ({
                             ref={overlayRef}
                             scrollRef={scrollRef}
                             legacyFooter={legacyFooter}
+                            fitContent={fitContent}
                         >
                             {overlayRef?.current && children}
                         </Overlay>


### PR DESCRIPTION
Recently encountered an issue while using the `Flyout` component where the content inside it wasn't nearly as wide as its default 400px min-width which ended up looking like this:

<img width="777" alt="Screenshot 2022-01-26 at 12 00 49" src="https://user-images.githubusercontent.com/26199969/151151765-7aa04f3a-4e3e-47dd-a6f6-2f0706154546.png">

This PR fixes the issue by adding an optional prop to fit the `Flyout` component's width to the content inside it (setting min-width to 0).

End result: 

<img width="777" alt="Screenshot 2022-01-26 at 12 00 23" src="https://user-images.githubusercontent.com/26199969/151151799-d0fede93-d553-44e2-afae-41126479cc8c.png">
