### PR TITLE
Fix: Make areas around icons clickable

### DIFF
--- a/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
@@ -34,7 +34,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
                 {...focusProps}
                 id={useMemoizedId(id)}
                 className={merge([
-                    "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none tw-py-2 tw-px-3 tw-min-h-[34px] tw-pr-10",
+                    "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none tw-py-2 tw-pl-3 tw-min-h-[34px] tw-pr-7",
                     !currentColor && "tw-text-black-60",
                     disabled && "tw-text-black-40",
                 ])}

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -196,10 +196,9 @@ describe("Dropdown Component", () => {
         const MARGIN_TOP = 17;
         mount(<Component menuBlocks={ITEMS} placeholder="Select item" />);
         cy.get(MENU_ITEM_TITLE_ID).contains("Select item");
-        cy
-            .get(TRIGGER_ID)
+        cy.get(TRIGGER_ID)
             .invoke("css", "width")
-            .then((width) => cy.get(TRIGGER_ID).click(parseInt(width.toString()) - MARGIN_RIGHT, MARGIN_TOP)),
-            cy.get(MENU_ITEM_LIST_ID).children().should("have.length", 5);
+            .then((width) => cy.get(TRIGGER_ID).click(parseInt(width.toString()) - MARGIN_RIGHT, MARGIN_TOP));
+        cy.get(MENU_ITEM_LIST_ID).children().should("have.length", 5);
     });
 });

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -190,4 +190,16 @@ describe("Dropdown Component", () => {
             expect(height).to.equal(130);
         });
     });
+
+    it("should open dropdown on click next to the caret icon", () => {
+        const MARGIN_RIGHT = 6;
+        const MARGIN_TOP = 17;
+        mount(<Component menuBlocks={ITEMS} placeholder="Select item" />);
+        cy.get(MENU_ITEM_TITLE_ID).contains("Select item");
+        cy
+            .get(TRIGGER_ID)
+            .invoke("css", "width")
+            .then((width) => cy.get(TRIGGER_ID).click(parseInt(width.toString()) - MARGIN_RIGHT, MARGIN_TOP)),
+            cy.get(MENU_ITEM_LIST_ID).children().should("have.length", 5);
+    });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -99,6 +99,18 @@ export const Dropdown: FC<DropdownProps> = ({
 
     const textClass = menuItemTextColorRecord[activeItem?.style || MenuItemStyle.Primary][textState];
 
+    const onClear = clearable
+        ? () => {
+              state.setSelectedKey("");
+              const first = state.collection.getFirstKey();
+              if (first) {
+                  state.selectionManager.setFocusedKey(first);
+              }
+          }
+        : undefined;
+
+    const showClear = !!activeItem && !!onClear;
+
     return (
         <div className="tw-relative tw-w-full tw-font-sans tw-text-s">
             <Trigger
@@ -106,19 +118,9 @@ export const Dropdown: FC<DropdownProps> = ({
                 buttonProps={buttonProps}
                 isFocusVisible={!disabled && isFocusVisible}
                 isOpen={isOpen}
-                clearable={!!activeItem}
                 size={size === DropdownSize.Large ? TriggerSize.Large : TriggerSize.Small}
-                onClear={
-                    clearable
-                        ? () => {
-                              state.setSelectedKey("");
-                              const first = state.collection.getFirstKey();
-                              if (first) {
-                                  state.selectionManager.setFocusedKey(first);
-                              }
-                          }
-                        : undefined
-                }
+                onClear={onClear}
+                showClear={showClear}
             >
                 <HiddenSelect state={state} triggerRef={triggerRef} />
                 <button
@@ -127,10 +129,11 @@ export const Dropdown: FC<DropdownProps> = ({
                     ref={triggerRef}
                     data-test-id="dropdown-trigger"
                     className={merge([
-                        "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none tw-pr-2",
+                        "tw-overflow-hidden tw-flex-auto tw-h-full tw-rounded tw-text-left tw-outline-none",
                         size === DropdownSize.Small
                             ? "tw-py-2 tw-pl-3 tw-min-h-[34px]"
                             : "tw-pl-5 tw-py-4 tw-min-h-[60px]",
+                        showClear ? "tw-pr-11" : "tw-pr-7",
                         !activeItem && "tw-text-black-60",
                         textClass,
                     ])}

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -94,7 +94,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                 <div
                     {...mergeProps(buttonProps, focusProps)}
                     ref={triggerRef}
-                    className="tw-flex-1 tw-flex tw-flex-wrap tw-gap-1 tw-px-[19px] tw-py-[11px] tw-min-h-[34px] tw-outline-none"
+                    className="tw-flex-1 tw-flex tw-flex-wrap tw-gap-1 tw-pl-[19px] tw-py-[11px] tw-min-h-[34px] tw-outline-none tw-pr-7"
                 >
                     {type === MultiSelectType.Default &&
                         activeItemKeys.map((key) => (

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -56,7 +56,7 @@ export const Tag: FC<TagProps> = ({ type, label, onClick }) => {
         <button
             data-test-id="tag"
             className={merge([
-                "tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group tw-px-2.5 tw-py-1",
+                "tw-inline-flex tw-items-center tw-border tw-border-solid tw-rounded-full tw-text-xs tw-transition-colors tw-group tw-px-2.5 tw-py-1 tw-break-word",
                 tagStyles[type],
                 isClickable ? "tw-cursor-pointer" : "tw-cursor-default",
                 isFocusVisible && FOCUS_STYLE,

--- a/src/components/Trigger/Trigger.tsx
+++ b/src/components/Trigger/Trigger.tsx
@@ -16,11 +16,11 @@ export enum TriggerSize {
 export type TriggerProps = {
     disabled?: boolean;
     isOpen?: boolean;
-    clearable?: boolean;
     onClear?: () => void;
     buttonProps?: HTMLAttributes<HTMLElement>;
     isFocusVisible?: boolean;
     size?: TriggerSize;
+    showClear?: boolean;
 };
 
 export const Trigger: FC<TriggerProps> = ({
@@ -28,14 +28,12 @@ export const Trigger: FC<TriggerProps> = ({
     onClear,
     children,
     disabled = false,
-    clearable = false,
     isOpen = false,
     isFocusVisible = false,
     size = TriggerSize.Small,
+    showClear = false,
 }) => {
     const { focusProps: clearableFocusProps, isFocusVisible: isClearFocusVisible } = useFocusRing();
-
-    const showClear = clearable && !!onClear;
 
     return (
         <div
@@ -54,8 +52,8 @@ export const Trigger: FC<TriggerProps> = ({
             {children}
             <div
                 className={merge([
-                    "tw-flex-none tw-flex tw-items-center",
-                    size === TriggerSize.Large ? "tw-pr-5 tw-gap-1.5" : "tw-pr-3 tw-gap-1",
+                    "tw-flex-none tw-flex tw-items-center tw-absolute",
+                    size === TriggerSize.Large ? "tw-right-5 tw-gap-1.5" : "tw-right-3 tw-gap-1",
                 ])}
             >
                 {showClear && (
@@ -64,11 +62,11 @@ export const Trigger: FC<TriggerProps> = ({
                         data-test-id="dropdown-clear-button"
                         aria-label="Clear selection"
                         className={merge([
-                            "tw-p-0 tw-outline-none",
+                            "tw-p-0 tw-outline-none tw-absolute tw-right-5",
                             isClearFocusVisible && FOCUS_STYLE,
                             disabled ? "tw-pointer-events-none tw-text-black-40" : "tw-text-black-80",
                         ])}
-                        onClick={() => onClear()}
+                        onClick={() => !!onClear && onClear()}
                     >
                         <IconReject size={IconSize.Size12} />
                     </button>


### PR DESCRIPTION
This fix resolves issues related to the areas around the caret and clear icons not being clickable:

https://user-images.githubusercontent.com/26199969/151188319-471106d8-ff75-4f22-adf1-cd16cb393ecd.mov

Issues are resolved using `position: absolute` while adding enough padding for the input to not get covered by the icons.

End result:

https://user-images.githubusercontent.com/26199969/151188450-245c3d28-1575-4e4c-b23b-7afeabcbc89c.mov

A test is added to the test suite to prevent this from happening in the future.

Admittedly, the test could be improved (it takes the width of the element and subtracts some pixels from it to target the area where the bug occurs), but it works well on all screen widths I used to verify its correctness.
Another test could be added to test the area around the clear icon, but this would require very precise coordinates to target correctly so I haven't done it at this stage.
If I find a nice way of doing it, I'll make sure to include it in the test suite in the future.
