### PR TITLE
fix(Flyout): adjust Flyout positioning calculation

### DIFF
--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -1,40 +1,16 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { FieldsetHeader } from "@components/FieldsetHeader/FieldsetHeader";
-import { Badge, BadgeProps } from "@components/Badge/Badge";
-import { Button, ButtonStyle } from "@components/Button/Button";
-import IconCheck from "@foundation/Icon/Generated/IconCheck";
+import { BadgeProps } from "@components/Badge/Badge";
 import { watchModals } from "@react-aria/aria-modal-polyfill";
 import { useButton } from "@react-aria/button";
-import { useDialog } from "@react-aria/dialog";
 import { FocusScope, useFocusRing } from "@react-aria/focus";
-import {
-    DismissButton,
-    OverlayContainer,
-    OverlayProvider,
-    useModal,
-    useOverlay,
-    useOverlayPosition,
-    useOverlayTrigger,
-} from "@react-aria/overlays";
+import { OverlayContainer, OverlayProvider, useOverlayPosition, useOverlayTrigger } from "@react-aria/overlays";
 import { mergeProps } from "@react-aria/utils";
 import { useOverlayTriggerState } from "@react-stately/overlays";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
 import { merge } from "@utilities/merge";
-import React, {
-    Children,
-    FC,
-    forwardRef,
-    ForwardRefRenderFunction,
-    HTMLAttributes,
-    MouseEvent,
-    PropsWithChildren,
-    ReactNode,
-    RefObject,
-    useEffect,
-    useMemo,
-    useRef,
-} from "react";
+import React, { FC, MouseEvent, PropsWithChildren, ReactNode, RefObject, useEffect, useMemo, useRef } from "react";
+import { Overlay } from "./Overlay";
 import { useContainScroll } from "./useContainScroll";
 
 export const FLYOUT_DIVIDER_COLOR = "#eaebeb";
@@ -58,94 +34,6 @@ export type FlyoutProps = PropsWithChildren<{
      */
     legacyFooter?: boolean;
 }>;
-
-type OverlayProps = Omit<FlyoutProps, "trigger" | "onOpenChange"> & {
-    positionProps: HTMLAttributes<Element>;
-    overlayTriggerProps: HTMLAttributes<Element>;
-    scrollRef: RefObject<HTMLDivElement>;
-    innerOverlayRef: RefObject<HTMLDivElement>;
-};
-
-const OverlayComponent: ForwardRefRenderFunction<HTMLDivElement, OverlayProps> = (
-    {
-        title,
-        decorator,
-        badges = [],
-        onClick,
-        onClose,
-        children,
-        isOpen,
-        positionProps,
-        overlayTriggerProps,
-        scrollRef,
-        innerOverlayRef,
-        legacyFooter,
-        fixedHeader,
-        fitContent,
-    },
-    ref,
-) => {
-    const { overlayProps } = useOverlay({ onClose, isOpen, isDismissable: true }, ref as RefObject<HTMLDivElement>);
-    const { modalProps } = useModal();
-    const { dialogProps, titleProps } = useDialog({}, ref as RefObject<HTMLDivElement>);
-
-    return (
-        <div
-            {...mergeProps(overlayProps, dialogProps, modalProps, positionProps, overlayTriggerProps)}
-            ref={ref}
-            className={merge([
-                "tw-max-h-full tw-flex tw-shadow-mid tw-outline-none",
-                fitContent ? "tw-min-w-0" : "tw-min-w-[400px]",
-            ])}
-        >
-            <div className="tw-flex tw-flex-col tw-flex-auto tw-min-h-0" ref={innerOverlayRef}>
-                {fixedHeader}
-                <div
-                    ref={scrollRef}
-                    className="tw-flex tw-overflow-y-auto tw-overflow-x-hidden tw-flex-col tw-divide-y tw-divide tw-divide-black-10 tw-rounded tw-bg-white tw-text-black dark:tw-text-white dark:tw-bg-black-95"
-                >
-                    {title && (
-                        <div className="tw-flex tw-justify-between tw-flex-wrap tw-gap-3 tw-p-8">
-                            <div {...titleProps} className="tw-inline-flex">
-                                <FieldsetHeader decorator={decorator}>{title}</FieldsetHeader>
-                            </div>
-                            <div className="tw-inline-flex tw-gap-2 tw-flex-wrap">
-                                {badges.map((badgeProps, index) => (
-                                    <Badge {...badgeProps} key={`flyout-badge-${index}`} />
-                                ))}
-                            </div>
-                        </div>
-                    )}
-                    {Children.map(children, (child, index) => (
-                        <div key={index}>{child}</div>
-                    ))}
-
-                    <DismissButton onDismiss={onClose} />
-                </div>
-                {legacyFooter && (
-                    <div className="tw-flex tw-gap-x-3 tw-justify-end tw-py-5 tw-px-8 tw-border-t tw-border-t-black-10 tw-bg-white dark:tw-bg-black-95 tw-z-40">
-                        {onClick ? (
-                            <>
-                                <Button onClick={onClose} style={ButtonStyle.Secondary}>
-                                    Cancel
-                                </Button>
-                                <Button onClick={onClick} icon={<IconCheck />}>
-                                    Confirm
-                                </Button>
-                            </>
-                        ) : (
-                            <Button onClick={onClose} style={ButtonStyle.Secondary}>
-                                Close
-                            </Button>
-                        )}
-                    </div>
-                )}
-            </div>
-        </div>
-    );
-};
-
-export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(OverlayComponent);
 
 export const Flyout: FC<FlyoutProps> = ({
     trigger,

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -66,14 +66,8 @@ export const Flyout: FC<FlyoutProps> = ({
 
     const ariaScrollCalculationRef = useMemo(() => {
         if (scrollRef.current && innerOverlayRef.current) {
-            const { scrollHeight: outerScrollHeight } = innerOverlayRef.current;
-            const {
-                scrollTop,
-                scrollHeight: innerScrollHeight,
-                clientHeight: innerClientHeight,
-                scrollLeft,
-                scrollWidth,
-            } = scrollRef.current;
+            const outerScrollHeight = innerOverlayRef.current.scrollHeight;
+            const { scrollHeight: innerScrollHeight, clientHeight: innerClientHeight } = scrollRef.current;
             /* The scrollRef passed to useOverlayPosition is used by react-aria to determine if the height should flip.
             Since the only properties it needs are the 4 below, and since it expects the scrollable content to be the
             outermost container, we need to combine the scrollHeights of the innerOverlay and the scrollRef so that it
@@ -81,13 +75,12 @@ export const Flyout: FC<FlyoutProps> = ({
 
             return {
                 current: {
-                    scrollTop,
+                    ...scrollRef.current,
                     scrollHeight: outerScrollHeight + (innerScrollHeight - innerClientHeight),
-                    scrollLeft,
-                    scrollWidth,
                 },
             } as RefObject<HTMLDivElement>;
         }
+
         return scrollRef;
     }, [innerOverlayRef.current, scrollRef.current?.scrollHeight, scrollRef.current?.clientHeight]);
 

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -178,8 +178,14 @@ export const Flyout: FC<FlyoutProps> = ({
 
     const ariaScrollCalculationRef = useMemo(() => {
         if (scrollRef.current && innerOverlayRef.current) {
-            const { scrollTop, scrollHeight, scrollLeft, scrollWidth } = innerOverlayRef.current;
-            const { scrollHeight: innerScrollHeight, clientHeight } = scrollRef.current;
+            const { scrollHeight: outerScrollHeight } = innerOverlayRef.current;
+            const {
+                scrollTop,
+                scrollHeight: innerScrollHeight,
+                clientHeight: innerClientHeight,
+                scrollLeft,
+                scrollWidth,
+            } = scrollRef.current;
             /* The scrollRef passed to useOverlayPosition is used by react-aria to determine if the height should flip.
             Since the only properties it needs are the 4 below, and since it expects the scrollable content to be the
             outermost container, we need to combine the scrollHeights of the innerOverlay and the scrollRef so that it
@@ -188,7 +194,7 @@ export const Flyout: FC<FlyoutProps> = ({
             return {
                 current: {
                     scrollTop,
-                    scrollHeight: scrollHeight + (innerScrollHeight - clientHeight),
+                    scrollHeight: outerScrollHeight + (innerScrollHeight - innerClientHeight),
                     scrollLeft,
                     scrollWidth,
                 },

--- a/src/components/Flyout/Overlay.tsx
+++ b/src/components/Flyout/Overlay.tsx
@@ -1,0 +1,100 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { Badge } from "@components/Badge/Badge";
+import { Button, ButtonStyle } from "@components/Button/Button";
+import { FieldsetHeader } from "@components/FieldsetHeader/FieldsetHeader";
+import IconCheck from "@foundation/Icon/Generated/IconCheck";
+import { useDialog } from "@react-aria/dialog";
+import { DismissButton, useModal, useOverlay } from "@react-aria/overlays";
+import { mergeProps } from "@react-aria/utils";
+import { merge } from "@utilities/merge";
+import React, { Children, forwardRef, ForwardRefRenderFunction, HTMLAttributes, RefObject } from "react";
+import { FlyoutProps } from ".";
+
+type OverlayProps = Omit<FlyoutProps, "trigger" | "onOpenChange"> & {
+    positionProps: HTMLAttributes<Element>;
+    overlayTriggerProps: HTMLAttributes<Element>;
+    scrollRef: RefObject<HTMLDivElement>;
+    innerOverlayRef: RefObject<HTMLDivElement>;
+};
+
+const OverlayComponent: ForwardRefRenderFunction<HTMLDivElement, OverlayProps> = (
+    {
+        title,
+        decorator,
+        badges = [],
+        onClick,
+        onClose,
+        children,
+        isOpen,
+        positionProps,
+        overlayTriggerProps,
+        scrollRef,
+        innerOverlayRef,
+        legacyFooter,
+        fixedHeader,
+        fitContent,
+    },
+    ref,
+) => {
+    const { overlayProps } = useOverlay({ onClose, isOpen, isDismissable: true }, ref as RefObject<HTMLDivElement>);
+    const { modalProps } = useModal();
+    const { dialogProps, titleProps } = useDialog({}, ref as RefObject<HTMLDivElement>);
+
+    return (
+        <div
+            {...mergeProps(overlayProps, dialogProps, modalProps, positionProps, overlayTriggerProps)}
+            ref={ref}
+            className={merge([
+                "tw-max-h-full tw-flex tw-shadow-mid tw-outline-none",
+                fitContent ? "tw-min-w-0" : "tw-min-w-[400px]",
+            ])}
+        >
+            <div className="tw-flex tw-flex-col tw-flex-auto tw-min-h-0" ref={innerOverlayRef}>
+                {fixedHeader}
+                <div
+                    ref={scrollRef}
+                    className="tw-flex tw-overflow-y-auto tw-overflow-x-hidden tw-flex-col tw-divide-y tw-divide tw-divide-black-10 tw-rounded tw-bg-white tw-text-black dark:tw-text-white dark:tw-bg-black-95"
+                >
+                    {title && (
+                        <div className="tw-flex tw-justify-between tw-flex-wrap tw-gap-3 tw-p-8">
+                            <div {...titleProps} className="tw-inline-flex">
+                                <FieldsetHeader decorator={decorator}>{title}</FieldsetHeader>
+                            </div>
+                            <div className="tw-inline-flex tw-gap-2 tw-flex-wrap">
+                                {badges.map((badgeProps, index) => (
+                                    <Badge {...badgeProps} key={`flyout-badge-${index}`} />
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                    {Children.map(children, (child, index) => (
+                        <div key={index}>{child}</div>
+                    ))}
+
+                    <DismissButton onDismiss={onClose} />
+                </div>
+                {legacyFooter && (
+                    <div className="tw-flex tw-gap-x-3 tw-justify-end tw-py-5 tw-px-8 tw-border-t tw-border-t-black-10 tw-bg-white dark:tw-bg-black-95 tw-z-40">
+                        {onClick ? (
+                            <>
+                                <Button onClick={onClose} style={ButtonStyle.Secondary}>
+                                    Cancel
+                                </Button>
+                                <Button onClick={onClick} icon={<IconCheck />}>
+                                    Confirm
+                                </Button>
+                            </>
+                        ) : (
+                            <Button onClick={onClose} style={ButtonStyle.Secondary}>
+                                Close
+                            </Button>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(OverlayComponent);


### PR DESCRIPTION
This new logic is required to bridge the gap in logic between the Flyout component and the internals of react-aria useOverlay. React aria expects that the scrollRef is the outermost component of the overlay, and checks whether there is more pixels available in the preferred position than the scrollHeight of the scrollRef component and if not, it flips the position to the opposite side. 

Since the Flyout also must have the option to add a fixed header and a fixed footer, the size of these components must be added to the calculation that is done here https://github.com/adobe/react-spectrum/blob/7e8a7f69685139b3574453b424a5ad4c8fa4e808/packages/%40react-aria/overlays/src/calculatePosition.ts#L305, otherwise the function will not decide to flip the content because it thinks there is still enough pixels to display the scrollRef, resulting in a very tiny modal below the trigger.

To do this the scrollHeights are merged and passed into the useOverlayPosition as the scrollRef, since only these four properties are used https://github.com/adobe/react-spectrum/blob/7e8a7f69685139b3574453b424a5ad4c8fa4e808/packages/%40react-aria/overlays/src/calculatePosition.ts#L392 here within the overlay hook.