### PR TITLE
fix: decouple link chooser from clarify

### DIFF
--- a/src/components/LinkChooser/LinkChooser.spec.tsx
+++ b/src/components/LinkChooser/LinkChooser.spec.tsx
@@ -1,727 +1,730 @@
-// /* (c) Copyright Frontify Ltd., all rights reserved. */
-
-// import { SelectionIndicatorIcon } from "@components/MenuItem/MenuItem";
-// import { MenuItemContentSize } from "@components/MenuItem/MenuItemContent";
-// import { Validation } from "@components/TextInput";
-// import { mount } from "@cypress/react";
-// import React from "react";
-// import { LinkChooser, QUERIES_STORAGE_KEY } from "./LinkChooser";
-// import { data } from "./mock/data";
-// import { guidelineSection } from "./mock/guidelines";
-// import { templateSection } from "./mock/templates";
-// import { LinkChooserProps, SearchResult, validationClassMap } from "./types";
-// import { doesContainSubstring } from "./utils/helpers";
-
-// const LINK_CHOOSER_ID = "[data-test-id=link-chooser]";
-// const SEARCH_WRAPPER_ID = "[data-test-id=link-chooser-search-wrapper]";
-// const EMPTY_RESULTS_ID = "[data-test-id=link-chooser-empty-results]";
-// const LOADER_ID = "[data-test-id=link-chooser-loader]";
-// const ERROR_ID = "[data-test-id=link-chooser-error]";
-// const SEARCH_INPUT_ID = "[data-test-id=link-chooser-search-input]";
-// const PREVIEW_ICON_ID = "[data-test-id=link-chooser-preview-icon]";
-// const COPY_ICON_ID = "[data-test-id=link-chooser-copy-icon]";
-// const CLEAR_ICON_ID = "[data-test-id=link-chooser-clear-icon]";
-// const SELECT_SECTION_ID = "[data-test-id=link-chooser-select-section]";
-// const RESULTS_LIST_ID = "[data-test-id=link-chooser-results-list]";
-// const ACTION_MENU_ID = "[data-test-id=link-chooser-action-menu]";
-// const BACK_BUTTON_ID = "[data-test-id=link-chooser-back-button]";
-// const NEW_TAB_ID = "[data-test-id=link-chooser-new-tab]";
-// const CHECKBOX_LABEL_ID = "[data-test-id=input-label]";
-// const DROPDOWN_WRAPPER_ID = "[data-test-id=link-chooser-dropdown]";
-// const DECORATOR_ICON_ID = "[data-test-id=link-chooser-decorator-icon]";
-// const LABEL_ID = "[data-test-id='link-chooser-label']";
-// const REQUIRED_ID = "[data-test-id='link-chooser-label-required']";
-// const MENU_ITEM = "[data-test-id='link-chooser-navigation-menu-item']";
-
-// const DEFAULT_TIMEOUT = 100;
-// const CUSTOM_QUERY = "Custom link";
-// const SELECTED_CLASS = "tw-text-violet-60";
-// const FOCUSED_OPTION_CLASS = "tw-bg-black-0";
-// const FIRST_TEMPLATE_TITLE = templateSection.items[0].title;
-// const FIRST_GUIDELINE_TITLE = guidelineSection.items[0].title;
-
-// const PREFILLED_LOCAL_STORAGE = [
-//     {
-//         id: "10",
-//         title: "Malaya Poster",
-//         subtitle: "UNICEF Social Campaign",
-//         link: "",
-//         icon: "TEMPLATE",
-//         size: "Large",
-//         selectionIndicator: "None",
-//     },
-//     {
-//         id: "custom-link",
-//         title: "www.frontify.com",
-//         link: "www.frontify.com",
-//         icon: "LINK",
-//         size: "Large",
-//         selectionIndicator: "None",
-//     },
-//     {
-//         id: "4",
-//         title: '"www.website.com"',
-//         link: "https://www.frontify.com/en/digital-and-print-templates/",
-//         icon: "EXTERNAL",
-//         size: "Large",
-//         selectionIndicator: "None",
-//     },
-//     {
-//         id: "11",
-//         preview:
-//             "https://images.frontify.test/s3/frontify-dev-files/eyJwYXRoIjoibXNpcmljXC9hY2NvdW50c1wvYzRcLzFcL3Byb2plY3RzXC8yXC9hc3NldHNcL2MyXC8xMlwvYTFkYzA0YTJkYmQwZTkxMTRlOGM2ODQzMWVmMjU5OTMtMTYzNDMwMTQ1MS5qcGcifQ:msiric:MLRtZYQCaEyWpPqgpGbA6P20PDgvagyoowNOllXgoCk?width=2400&height={height}",
-//         title: "Brand Business Card",
-//         subtitle: "Corporate Library",
-//         link: "#",
-//         icon: "TEMPLATE",
-//         size: "Large",
-//         selectionIndicator: "None",
-//     },
-//     {
-//         id: "1",
-//         title: "Brand listening - A Memoir",
-//         subtitle: "Guideline XYZ",
-//         link: "https://www.frontify.com",
-//         icon: "DOCUMENT",
-//         size: "Large",
-//         selectionIndicator: "None",
-//     },
-// ];
-
-// const filterItems = (query: string, results: SearchResult[]): SearchResult[] =>
-//     results.filter((item) => doesContainSubstring(item.title, query, []));
-
-// const getLinkChooserComponent = (overwriteProps?: Partial<LinkChooserProps>, returnError = false) => {
-//     const getGlobalByQuery = (query: string): Promise<SearchResult[]> => {
-//         return new Promise((resolve, reject) =>
-//             setTimeout(() => {
-//                 returnError
-//                     ? reject()
-//                     : resolve(
-//                           filterItems(query, data).map((item) => ({
-//                               ...item,
-//                               size: MenuItemContentSize.Large,
-//                               selectionIndicator: SelectionIndicatorIcon.None,
-//                           })),
-//                       );
-//             }, DEFAULT_TIMEOUT),
-//         );
-//     };
-
-//     const getTemplatesByQueryMock = (query: string): Promise<SearchResult[]> => {
-//         return new Promise((resolve, reject) =>
-//             setTimeout(() => {
-//                 returnError ? reject() : resolve(filterItems(query, templateSection.items));
-//             }, DEFAULT_TIMEOUT),
-//         );
-//     };
-
-//     const getGuidelinesByQueryMock = (query: string): Promise<SearchResult[]> => {
-//         return new Promise((resolve, reject) =>
-//             setTimeout(() => {
-//                 returnError ? reject() : resolve(filterItems(query, guidelineSection.items));
-//             }, DEFAULT_TIMEOUT),
-//         );
-//     };
-
-//     const onLinkChange = cy.stub().as("onLinkChange");
-//     const onOpenInNewTabChange = cy.stub().as("onOpenInNewTabChange");
-//     const clipboardOptions = { writeText: cy.stub().as("clipboardOptions") };
-//     const openPreview = cy.stub().as("openPreview");
-
-//     return (
-//         <LinkChooser
-//             getGlobalByQuery={getGlobalByQuery}
-//             clipboardOptions={clipboardOptions}
-//             openPreview={openPreview}
-//             onLinkChange={onLinkChange}
-//             onOpenInNewTabChange={onOpenInNewTabChange}
-//             openInNewTab={false}
-//             {...overwriteProps}
-//         />
-//     );
-// };
-
-// describe("LinkChooser Component", () => {
-//     it("renders correctly", () => {
-//         mount(getLinkChooserComponent());
-
-//         cy.get(LINK_CHOOSER_ID).should("be.visible");
-//     });
-
-//     describe("Input", () => {
-//         it("renders input props Label", () => {
-//             const label = "LABEL";
-//             const placeholder = "PLACEHOLDER";
-//             mount(getLinkChooserComponent({ label, placeholder, required: true, validation: Validation.Error }));
-
-//             cy.get(LABEL_ID).should("contain", label);
-//             cy.get(REQUIRED_ID).should("have.text", "*");
-//             cy.get(SEARCH_INPUT_ID).invoke("attr", "placeholder").should("equal", placeholder);
-//             cy.get(SEARCH_WRAPPER_ID).should("have.class", validationClassMap[Validation.Error]);
-//         });
-
-//         it("disables input and checkbox", () => {
-//             mount(getLinkChooserComponent({ disabled: true }));
-
-//             cy.get(SEARCH_INPUT_ID).should("be.disabled");
-//             cy.get("input[type='checkbox']").should("be.disabled");
-//         });
-//     });
-
-//     describe("Empty localStorage", () => {
-//         beforeEach(() => {
-//             localStorage.removeItem(QUERIES_STORAGE_KEY);
-//         });
-
-//         it("displays empty results on click", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SELECT_SECTION_ID).should("not.exist");
-//             cy.get(PREVIEW_ICON_ID).should("not.exist");
-//             cy.get(COPY_ICON_ID).should("not.exist");
-//             cy.get(CLEAR_ICON_ID).should("not.exist");
-//             cy.get(EMPTY_RESULTS_ID).should("exist");
-//         });
-
-//         it("opens dropdown on focus and/or typing, closes on escape", () => {
-//             mount(getLinkChooserComponent());
-//             cy.window().focus();
-//             cy.get("body").realPress("Tab");
-//             cy.get(SEARCH_INPUT_ID).should("be.focused");
-//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-//             cy.get(SEARCH_INPUT_ID).realPress("Escape");
-//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-//             cy.get(SEARCH_INPUT_ID).type(" ");
-//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-//         });
-
-//         it("shows loading animation and loads results", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(SELECT_SECTION_ID)
-//                 .children()
-//                 .should("have.length", filterItems(data[0].title, data).length + 1);
-//         });
-
-//         it("selects first item", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
-//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-//             cy.get("@onLinkChange").should("be.calledOnce");
-//         });
-
-//         it("opens in new tab", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(`${NEW_TAB_ID} ${CHECKBOX_LABEL_ID}`).click();
-//             cy.get("@onOpenInNewTabChange").should("be.calledOnce");
-//         });
-
-//         it("opens preview", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(PREVIEW_ICON_ID).click();
-//             cy.get("@openPreview").should("be.calledOnce");
-//         });
-
-//         it("copies to clipboard", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(COPY_ICON_ID).click();
-//             cy.get("@clipboardOptions").should("be.calledOnce");
-//         });
-
-//         it("clears the search input", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(CLEAR_ICON_ID).click();
-//             cy.get("@onLinkChange").should("be.called");
-//             cy.get(SEARCH_INPUT_ID).should("be.empty");
-//         });
-
-//         it("displays a custom link", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get("@onLinkChange").should("be.called");
-//             cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
-//         });
-
-//         it("hides dropdown on blur", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(DROPDOWN_WRAPPER_ID).should("exist");
-//             cy.get(SEARCH_INPUT_ID).blur();
-//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-//         });
-
-//         it("adds selected item to local storage", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(CLEAR_ICON_ID).click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SELECT_SECTION_ID).children().should("have.length", 1);
-//         });
-
-//         it("interrupts the fetching phase and selects the query as custom link", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-//             cy.get(SEARCH_INPUT_ID).blur();
-//             cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(`${SELECT_SECTION_ID} > li > div`)
-//                 .eq(0)
-//                 .should(($container) => {
-//                     expect($container).to.have.css("font-weight", "500");
-//                 });
-//         });
-
-//         it("adds a new custom link to local storage each time, unless matching text", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type("1");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 2);
-//             cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}1`);
-//             cy.get(SEARCH_INPUT_ID).type("{Backspace}2");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 3);
-//             cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}2`);
-//             cy.get(SEARCH_INPUT_ID).type("{Backspace}1");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 3);
-//             cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}1`);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(1).should("contain.text", `${CUSTOM_QUERY}2`);
-//         });
-
-//         it("resumes fetching when dropdown opens if the fetching phase was previously interrupted", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get("body").click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(SELECT_SECTION_ID)
-//                 .children()
-//                 .should("have.length", filterItems(data[0].title, data).length + 1);
-//         });
-
-//         it("does not resume fetching when dropdown opens if the fetching phase was previously resolved", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get("body").click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(LOADER_ID).should("not.exist");
-//         });
-
-//         it("selects existing document and reselects it on interrupt if the titles match", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type("{backspace}");
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title[data[0].title.length - 1]);
-//             cy.get("body").click();
-//             cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
-//             cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconDocument");
-//         });
-
-//         it("selects existing document and does not reselect it on interrupt if the titles do not match", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).clear();
-//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-//             cy.get("body").click();
-//             cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
-//             cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconLink");
-//         });
-
-//         it("Creates and selects a custom link if enter pressed and no item is focused, even when loading", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-//             cy.get(DROPDOWN_WRAPPER_ID).should("exist");
-//             cy.get(LOADER_ID).should("be.visible");
-//             cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
-//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
-//             cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
-//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-//             cy.get(DROPDOWN_WRAPPER_ID).should("exist");
-//             cy.get(`${SELECT_SECTION_ID} > li > div`)
-//                 .eq(0)
-//                 .should(($container) => {
-//                     expect($container).to.have.css("font-weight", "500");
-//                 });
-//         });
-
-//         it("resets selection if input is empty", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconDocument");
-//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-//             cy.get("@onLinkChange").should("be.calledOnce");
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).clear();
-//             cy.get("@onLinkChange").should("be.calledTwice");
-//             cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
-//         });
-
-//         it("displays error message when fetching fails", () => {
-//             mount(getLinkChooserComponent({}, true));
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(SELECT_SECTION_ID).should("not.exist");
-//             cy.get(ERROR_ID).should("exist");
-//         });
-//     });
-
-//     describe("Filled localStorage", () => {
-//         beforeEach(() => {
-//             localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
-//         });
-
-//         it("displays recent queries on click", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(PREVIEW_ICON_ID).should("not.exist");
-//             cy.get(COPY_ICON_ID).should("not.exist");
-//             cy.get(CLEAR_ICON_ID).should("not.exist");
-//             cy.get(EMPTY_RESULTS_ID).should("not.exist");
-//             cy.get(SELECT_SECTION_ID)
-//                 .children()
-//                 .should("have.length", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null").length);
-//         });
-
-//         it("replaces first item with the most recent selection", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").should(
-//                 "contain",
-//                 JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title,
-//             );
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(3).as("thirdSelectItem");
-//             cy.get("@thirdSelectItem").click();
-//             cy.get(CLEAR_ICON_ID).click();
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("newFirstSelectItem");
-//             cy.get("@newFirstSelectItem").should(
-//                 "contain",
-//                 JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[3].title,
-//             );
-//         });
-
-//         it("replaces local storage results with search results on search input change", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(SELECT_SECTION_ID)
-//                 .children()
-//                 .should("have.length", filterItems(data[0].title, data).length + 1);
-//         });
-//     });
-
-//     describe("Templates section", () => {
-//         it("displays all templates when query is empty", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(BACK_BUTTON_ID).should("not.exist");
-//             cy.get(ACTION_MENU_ID).contains("Templates").click();
-//             cy.get(MENU_ITEM).should("have.length", 1).and("have.text", "templates");
-//             cy.get(SELECT_SECTION_ID).children().should("have.length", templateSection.items.length);
-//         });
-
-//         it("shows loading animation and loads results", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(FIRST_TEMPLATE_TITLE, data).length);
-//         });
-
-//         it("searches the same query when switching from default view to templates view", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
-//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(FIRST_TEMPLATE_TITLE, data).length);
-//         });
-
-//         it("searches the same query when switching from templates view to default view", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
-//             cy.get(MENU_ITEM).click();
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(FIRST_TEMPLATE_TITLE, data).length);
-//         });
-
-//         it("selects first item", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_TEMPLATE_TITLE);
-
-//             cy.get("@onLinkChange").should("be.calledOnce");
-//         });
-
-//         it("does not display a custom link", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-//             cy.get(EMPTY_RESULTS_ID).should("exist");
-//         });
-
-//         it("repopulates default view with recent queries when selected", () => {
-//             localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SELECT_SECTION_ID)
-//                 .first()
-//                 .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
-//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_TEMPLATE_TITLE);
-//             cy.get(SELECT_SECTION_ID).should("not.exist");
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(`${SELECT_SECTION_ID} > li`).first().should("contain", FIRST_TEMPLATE_TITLE);
-//             cy.get(`${SELECT_SECTION_ID} > li`)
-//                 .eq(1)
-//                 .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
-//         });
-
-//         it("can be navigated to by keyboard", () => {
-//             mount(getLinkChooserComponent());
-//             cy.window().focus();
-//             cy.get("body").realPress("Tab");
-//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
-//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-//             cy.get(MENU_ITEM).first().should("not.have.class", FOCUSED_OPTION_CLASS);
-//             cy.get(MENU_ITEM).eq(1).should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "Templates");
-//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
-//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-//             cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
-//             cy.get("@firstSelectItem").should("contain.text", FIRST_TEMPLATE_TITLE);
-//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "templates");
-//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-//             cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
-//             cy.get(SEARCH_INPUT_ID).realPress("ArrowUp");
-//             cy.get(`@firstSelectItem`).should("not.have.class", FOCUSED_OPTION_CLASS);
-//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
-//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
-//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-//             cy.get(EMPTY_RESULTS_ID).should("be.visible");
-//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
-//             cy.get(`@firstSelectItem`)
-//                 .should("not.have.class", FOCUSED_OPTION_CLASS)
-//                 .and("contain.text", data[0].title);
-//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-//             cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
-//             cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
-//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
-//             cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
-//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-//         });
-//     });
-
-//     describe("Guidelines Section", () => {
-//         it("displays all guidelines when query is empty", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(BACK_BUTTON_ID).should("not.exist");
-//             cy.get(ACTION_MENU_ID).contains("Guidelines").click();
-//             cy.get(MENU_ITEM).should("have.length", 1).and("have.text", "guidelines");
-//             cy.get(SELECT_SECTION_ID).children().should("have.length", guidelineSection.length);
-//         });
-
-//         it("shows loading animation and loads results", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(RESULTS_LIST_ID)
-//                 .children()
-//                 .should("have.length", filterItems(FIRST_GUIDELINE_TITLE, guidelineSection).length);
-//         });
-
-//         it("searches the same query when switching from default view to guidelines view", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
-//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(RESULTS_LIST_ID)
-//                 .children()
-//                 .should("have.length", filterItems(FIRST_GUIDELINE_TITLE, guidelineSection).length);
-//         });
-
-//         it("searches the same query when switching from guidelines view to default view", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
-//             cy.get(MENU_ITEM).click();
-//             cy.get(LOADER_ID).should("exist");
-//             cy.get(RESULTS_LIST_ID)
-//                 .children()
-//                 .should("have.length", filterItems(FIRST_GUIDELINE_TITLE, guidelineSection).length);
-//         });
-
-//         it("selects first item", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_GUIDELINE_TITLE);
-//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-
-//             cy.get("@onLinkChange").should("be.calledOnce");
-//         });
-
-//         it("does not display a custom link", () => {
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-//             cy.get(EMPTY_RESULTS_ID).should("exist");
-//         });
-
-//         it("repopulates default view with recent queries when selected", () => {
-//             localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
-//             mount(getLinkChooserComponent());
-
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(SELECT_SECTION_ID)
-//                 .first()
-//                 .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
-//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
-//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-//             cy.get("@firstSelectItem").click();
-//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_GUIDELINE_TITLE);
-//             cy.get(SELECT_SECTION_ID).should("not.exist");
-//             cy.get(SEARCH_WRAPPER_ID).click();
-//             cy.get(`${SELECT_SECTION_ID} > li`).first().should("contain", FIRST_GUIDELINE_TITLE);
-//             cy.get(`${SELECT_SECTION_ID} > li`)
-//                 .eq(1)
-//                 .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
-//         });
-
-//         it("can be navigated to by keyboard", () => {
-//             mount(getLinkChooserComponent());
-//             cy.window().focus();
-//             cy.get("body").realPress("Tab");
-//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "Guidelines");
-//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
-//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-//             cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
-//             cy.get("@firstSelectItem").should("contain.text", FIRST_GUIDELINE_TITLE);
-//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "guidelines");
-//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-//             cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
-//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
-//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_GUIDELINE_TITLE);
-//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-//         });
-//     });
-// });
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { SelectionIndicatorIcon } from "@components/MenuItem/MenuItem";
+import { MenuItemContentSize } from "@components/MenuItem/MenuItemContent";
+import { Validation } from "@components/TextInput";
+import { mount } from "@cypress/react";
+import React from "react";
+import { LinkChooser, QUERIES_STORAGE_KEY } from "./LinkChooser";
+import { data } from "./mock/data";
+import { guidelineSection } from "./mock/guidelines";
+import { templateSection } from "./mock/templates";
+import { LinkChooserProps, SearchResult, validationClassMap } from "./types";
+import { filterItems } from "./utils/helpers";
+
+const LINK_CHOOSER_ID = "[data-test-id=link-chooser]";
+const SEARCH_WRAPPER_ID = "[data-test-id=link-chooser-search-wrapper]";
+const EMPTY_RESULTS_ID = "[data-test-id=link-chooser-empty-results]";
+const LOADER_ID = "[data-test-id=link-chooser-loader]";
+const ERROR_ID = "[data-test-id=link-chooser-error]";
+const SEARCH_INPUT_ID = "[data-test-id=link-chooser-search-input]";
+const PREVIEW_ICON_ID = "[data-test-id=link-chooser-preview-icon]";
+const COPY_ICON_ID = "[data-test-id=link-chooser-copy-icon]";
+const CLEAR_ICON_ID = "[data-test-id=link-chooser-clear-icon]";
+const SELECT_SECTION_ID = "[data-test-id=link-chooser-select-section]";
+const RESULTS_LIST_ID = "[data-test-id=link-chooser-results-list]";
+const ACTION_MENU_ID = "[data-test-id=link-chooser-action-menu]";
+const BACK_BUTTON_ID = "[data-test-id=link-chooser-back-button]";
+const NEW_TAB_ID = "[data-test-id=link-chooser-new-tab]";
+const CHECKBOX_LABEL_ID = "[data-test-id=input-label]";
+const DROPDOWN_WRAPPER_ID = "[data-test-id=link-chooser-dropdown]";
+const DECORATOR_ICON_ID = "[data-test-id=link-chooser-decorator-icon]";
+const LABEL_ID = "[data-test-id='link-chooser-label']";
+const REQUIRED_ID = "[data-test-id='link-chooser-label-required']";
+const MENU_ITEM = "[data-test-id='link-chooser-navigation-menu-item']";
+
+const DEFAULT_TIMEOUT = 100;
+const CUSTOM_QUERY = "Custom link";
+const SELECTED_CLASS = "tw-text-violet-60";
+const FOCUSED_OPTION_CLASS = "tw-bg-black-0";
+const TEMPLATE_TITLE = templateSection.title;
+const GUIDELINE_TITLE = guidelineSection.title;
+const FIRST_TEMPLATE_TITLE = templateSection.items[0].title;
+const FIRST_GUIDELINE_TITLE = guidelineSection.items[0].title;
+
+const PREFILLED_LOCAL_STORAGE = [
+    {
+        id: "10",
+        title: "Malaya Poster",
+        subtitle: "UNICEF Social Campaign",
+        link: "",
+        icon: "TEMPLATE",
+        size: "Large",
+        selectionIndicator: "None",
+    },
+    {
+        id: "custom-link",
+        title: "www.frontify.com",
+        link: "www.frontify.com",
+        icon: "LINK",
+        size: "Large",
+        selectionIndicator: "None",
+    },
+    {
+        id: "4",
+        title: '"www.website.com"',
+        link: "https://www.frontify.com/en/digital-and-print-templates/",
+        icon: "EXTERNAL",
+        size: "Large",
+        selectionIndicator: "None",
+    },
+    {
+        id: "11",
+        preview:
+            "https://images.frontify.test/s3/frontify-dev-files/eyJwYXRoIjoibXNpcmljXC9hY2NvdW50c1wvYzRcLzFcL3Byb2plY3RzXC8yXC9hc3NldHNcL2MyXC8xMlwvYTFkYzA0YTJkYmQwZTkxMTRlOGM2ODQzMWVmMjU5OTMtMTYzNDMwMTQ1MS5qcGcifQ:msiric:MLRtZYQCaEyWpPqgpGbA6P20PDgvagyoowNOllXgoCk?width=2400&height={height}",
+        title: "Brand Business Card",
+        subtitle: "Corporate Library",
+        link: "#",
+        icon: "TEMPLATE",
+        size: "Large",
+        selectionIndicator: "None",
+    },
+    {
+        id: "1",
+        title: "Brand listening - A Memoir",
+        subtitle: "Guideline XYZ",
+        link: "https://www.frontify.com",
+        icon: "DOCUMENT",
+        size: "Large",
+        selectionIndicator: "None",
+    },
+];
+
+const getLinkChooserComponent = (overwriteProps?: Partial<LinkChooserProps>, returnError = false) => {
+    const getGlobalByQuery = (query: string): Promise<SearchResult[]> => {
+        return new Promise((resolve, reject) =>
+            setTimeout(() => {
+                returnError
+                    ? reject()
+                    : resolve(
+                          filterItems(query, data).map((item) => ({
+                              ...item,
+                              size: MenuItemContentSize.Large,
+                              selectionIndicator: SelectionIndicatorIcon.None,
+                          })),
+                      );
+            }, DEFAULT_TIMEOUT),
+        );
+    };
+
+    const getTemplatesByQueryMock = (query: string): Promise<SearchResult[]> =>
+        new Promise((resolve, reject) =>
+            setTimeout(() => {
+                returnError ? reject() : resolve(filterItems(query, templateSection.items));
+            }, DEFAULT_TIMEOUT),
+        );
+
+    const getGuidelinesByQueryMock = (query: string): Promise<SearchResult[]> =>
+        new Promise((resolve, reject) =>
+            setTimeout(() => {
+                returnError ? reject() : resolve(filterItems(query, guidelineSection.items));
+            }, DEFAULT_TIMEOUT),
+        );
+
+    const extraSections = [
+        { ...guidelineSection, getResults: getGuidelinesByQueryMock },
+        { ...templateSection, getResults: getTemplatesByQueryMock },
+    ];
+
+    const onLinkChange = cy.stub().as("onLinkChange");
+    const onOpenInNewTabChange = cy.stub().as("onOpenInNewTabChange");
+    const clipboardOptions = { writeText: cy.stub().as("clipboardOptions") };
+    const openPreview = cy.stub().as("openPreview");
+
+    return (
+        <LinkChooser
+            getGlobalByQuery={getGlobalByQuery}
+            clipboardOptions={clipboardOptions}
+            openPreview={openPreview}
+            onLinkChange={onLinkChange}
+            onOpenInNewTabChange={onOpenInNewTabChange}
+            openInNewTab={false}
+            extraSections={extraSections}
+            {...overwriteProps}
+        />
+    );
+};
+
+describe("LinkChooser Component", () => {
+    it("renders correctly", () => {
+        mount(getLinkChooserComponent());
+
+        cy.get(LINK_CHOOSER_ID).should("be.visible");
+    });
+
+    describe("Input", () => {
+        it("renders input props Label", () => {
+            const label = "LABEL";
+            const placeholder = "PLACEHOLDER";
+            mount(getLinkChooserComponent({ label, placeholder, required: true, validation: Validation.Error }));
+
+            cy.get(LABEL_ID).should("contain", label);
+            cy.get(REQUIRED_ID).should("have.text", "*");
+            cy.get(SEARCH_INPUT_ID).invoke("attr", "placeholder").should("equal", placeholder);
+            cy.get(SEARCH_WRAPPER_ID).should("have.class", validationClassMap[Validation.Error]);
+        });
+
+        it("disables input and checkbox", () => {
+            mount(getLinkChooserComponent({ disabled: true }));
+
+            cy.get(SEARCH_INPUT_ID).should("be.disabled");
+            cy.get("input[type='checkbox']").should("be.disabled");
+        });
+    });
+
+    describe("Empty localStorage", () => {
+        beforeEach(() => {
+            localStorage.removeItem(QUERIES_STORAGE_KEY);
+        });
+
+        it("displays empty results on click", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SELECT_SECTION_ID).should("not.exist");
+            cy.get(PREVIEW_ICON_ID).should("not.exist");
+            cy.get(COPY_ICON_ID).should("not.exist");
+            cy.get(CLEAR_ICON_ID).should("not.exist");
+            cy.get(EMPTY_RESULTS_ID).should("exist");
+        });
+
+        it("opens dropdown on focus and/or typing, closes on escape", () => {
+            mount(getLinkChooserComponent());
+            cy.window().focus();
+            cy.get("body").realPress("Tab");
+            cy.get(SEARCH_INPUT_ID).should("be.focused");
+            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+            cy.get(SEARCH_INPUT_ID).realPress("Escape");
+            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+            cy.get(SEARCH_INPUT_ID).type(" ");
+            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+        });
+
+        it("shows loading animation and loads results", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(LOADER_ID).should("exist");
+            cy.get(SELECT_SECTION_ID)
+                .children()
+                .should("have.length", filterItems(data[0].title, data).length + 1);
+        });
+
+        it("selects first item", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
+            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+            cy.get("@onLinkChange").should("be.calledOnce");
+        });
+
+        it("opens in new tab", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(`${NEW_TAB_ID} ${CHECKBOX_LABEL_ID}`).click();
+            cy.get("@onOpenInNewTabChange").should("be.calledOnce");
+        });
+
+        it("opens preview", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(PREVIEW_ICON_ID).click();
+            cy.get("@openPreview").should("be.calledOnce");
+        });
+
+        it("copies to clipboard", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(COPY_ICON_ID).click();
+            cy.get("@clipboardOptions").should("be.calledOnce");
+        });
+
+        it("clears the search input", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(CLEAR_ICON_ID).click();
+            cy.get("@onLinkChange").should("be.called");
+            cy.get(SEARCH_INPUT_ID).should("be.empty");
+        });
+
+        it("displays a custom link", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get("@onLinkChange").should("be.called");
+            cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
+        });
+
+        it("hides dropdown on blur", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(DROPDOWN_WRAPPER_ID).should("exist");
+            cy.get(SEARCH_INPUT_ID).blur();
+            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+        });
+
+        it("adds selected item to local storage", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(CLEAR_ICON_ID).click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SELECT_SECTION_ID).children().should("have.length", 1);
+        });
+
+        it("interrupts the fetching phase and selects the query as custom link", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+            cy.get(SEARCH_INPUT_ID).blur();
+            cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(`${SELECT_SECTION_ID} > li > div`)
+                .eq(0)
+                .should(($container) => {
+                    expect($container).to.have.css("font-weight", "500");
+                });
+        });
+
+        it("adds a new custom link to local storage each time, unless matching text", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type("1");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 2);
+            cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}1`);
+            cy.get(SEARCH_INPUT_ID).type("{Backspace}2");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 3);
+            cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}2`);
+            cy.get(SEARCH_INPUT_ID).type("{Backspace}1");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 3);
+            cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}1`);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(1).should("contain.text", `${CUSTOM_QUERY}2`);
+        });
+
+        it("resumes fetching when dropdown opens if the fetching phase was previously interrupted", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get("body").click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(LOADER_ID).should("exist");
+            cy.get(SELECT_SECTION_ID)
+                .children()
+                .should("have.length", filterItems(data[0].title, data).length + 1);
+        });
+
+        it("does not resume fetching when dropdown opens if the fetching phase was previously resolved", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get("body").click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(LOADER_ID).should("not.exist");
+        });
+
+        it("selects existing document and reselects it on interrupt if the titles match", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type("{backspace}");
+            cy.get(SEARCH_INPUT_ID).type(data[0].title[data[0].title.length - 1]);
+            cy.get("body").click();
+            cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
+            cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconDocument");
+        });
+
+        it("selects existing document and does not reselect it on interrupt if the titles do not match", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).clear();
+            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+            cy.get("body").click();
+            cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
+            cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconLink");
+        });
+
+        it("Creates and selects a custom link if enter pressed and no item is focused, even when loading", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+            cy.get(DROPDOWN_WRAPPER_ID).should("exist");
+            cy.get(LOADER_ID).should("be.visible");
+            cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
+            cy.get(SEARCH_INPUT_ID).realPress("Enter");
+            cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
+            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+            cy.get(DROPDOWN_WRAPPER_ID).should("exist");
+            cy.get(`${SELECT_SECTION_ID} > li > div`)
+                .eq(0)
+                .should(($container) => {
+                    expect($container).to.have.css("font-weight", "500");
+                });
+        });
+
+        it("resets selection if input is empty", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconDocument");
+            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+            cy.get("@onLinkChange").should("be.calledOnce");
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).clear();
+            cy.get("@onLinkChange").should("be.calledTwice");
+            cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
+        });
+
+        it("displays error message when fetching fails", () => {
+            mount(getLinkChooserComponent({}, true));
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(SELECT_SECTION_ID).should("not.exist");
+            cy.get(ERROR_ID).should("exist");
+        });
+    });
+
+    describe("Filled localStorage", () => {
+        beforeEach(() => {
+            localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
+        });
+
+        it("displays recent queries on click", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(PREVIEW_ICON_ID).should("not.exist");
+            cy.get(COPY_ICON_ID).should("not.exist");
+            cy.get(CLEAR_ICON_ID).should("not.exist");
+            cy.get(EMPTY_RESULTS_ID).should("not.exist");
+            cy.get(SELECT_SECTION_ID)
+                .children()
+                .should("have.length", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null").length);
+        });
+
+        it("replaces first item with the most recent selection", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").should(
+                "contain",
+                JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title,
+            );
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(3).as("thirdSelectItem");
+            cy.get("@thirdSelectItem").click();
+            cy.get(CLEAR_ICON_ID).click();
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("newFirstSelectItem");
+            cy.get("@newFirstSelectItem").should(
+                "contain",
+                JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[3].title,
+            );
+        });
+
+        it("replaces local storage results with search results on search input change", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(LOADER_ID).should("exist");
+            cy.get(SELECT_SECTION_ID)
+                .children()
+                .should("have.length", filterItems(data[0].title, data).length + 1);
+        });
+    });
+
+    describe("Templates section", () => {
+        it("displays all templates when query is empty", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(BACK_BUTTON_ID).should("not.exist");
+            cy.get(ACTION_MENU_ID).contains(TEMPLATE_TITLE).click();
+            cy.get(MENU_ITEM).should("have.length", 1).and("have.text", TEMPLATE_TITLE);
+            cy.get(SELECT_SECTION_ID).children().should("have.length", templateSection.items.length);
+        });
+
+        it("shows loading animation and loads results", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(ACTION_MENU_ID).contains(TEMPLATE_TITLE).click({ waitForAnimations: true });
+            cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+            cy.get(LOADER_ID).should("exist");
+            cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(FIRST_TEMPLATE_TITLE, data).length);
+        });
+
+        it("searches the same query when switching from default view to templates view", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+            cy.get(ACTION_MENU_ID).contains(TEMPLATE_TITLE).click({ waitForAnimations: true });
+            cy.get(LOADER_ID).should("exist");
+            cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(FIRST_TEMPLATE_TITLE, data).length);
+        });
+
+        it("searches the same query when switching from templates view to default view", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(ACTION_MENU_ID).contains(TEMPLATE_TITLE).click({ waitForAnimations: true });
+            cy.get(LOADER_ID).should("exist");
+            cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+            cy.get(MENU_ITEM).click();
+            cy.get(LOADER_ID).should("exist");
+            cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(FIRST_TEMPLATE_TITLE, data).length);
+        });
+
+        it("selects first item", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(ACTION_MENU_ID).contains(TEMPLATE_TITLE).click({ waitForAnimations: true });
+            cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_TEMPLATE_TITLE);
+
+            cy.get("@onLinkChange").should("be.calledOnce");
+        });
+
+        it("does not display a custom link", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(ACTION_MENU_ID).contains(TEMPLATE_TITLE).click({ waitForAnimations: true });
+            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+            cy.get(EMPTY_RESULTS_ID).should("exist");
+        });
+
+        it("repopulates default view with recent queries when selected", () => {
+            localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SELECT_SECTION_ID)
+                .first()
+                .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
+            cy.get(ACTION_MENU_ID).contains(TEMPLATE_TITLE).click({ waitForAnimations: true });
+            cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_TEMPLATE_TITLE);
+            cy.get(SELECT_SECTION_ID).should("not.exist");
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(`${SELECT_SECTION_ID} > li`).first().should("contain", FIRST_TEMPLATE_TITLE);
+            cy.get(`${SELECT_SECTION_ID} > li`)
+                .eq(1)
+                .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
+        });
+
+        it("can be navigated to by keyboard", () => {
+            mount(getLinkChooserComponent());
+            cy.window().focus();
+            cy.get("body").realPress("Tab");
+            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+            cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
+            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+            cy.get(MENU_ITEM).first().should("not.have.class", FOCUSED_OPTION_CLASS);
+            cy.get(MENU_ITEM).eq(1).should("have.class", FOCUSED_OPTION_CLASS).and("have.text", TEMPLATE_TITLE);
+            cy.get(SEARCH_INPUT_ID).realPress("Enter");
+            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+            cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
+            cy.get("@firstSelectItem").should("contain.text", FIRST_TEMPLATE_TITLE);
+            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+            cy.get(MENU_ITEM).first().should("have.text", TEMPLATE_TITLE);
+            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+            cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
+            cy.get(SEARCH_INPUT_ID).realPress("Escape");
+            //TODO: add back button test section as soon as keyboard-navigation is fixed
+            // cy.get(SEARCH_INPUT_ID).realPress("ArrowUp");
+            // cy.get(`@firstSelectItem`).should("not.have.class", FOCUSED_OPTION_CLASS);
+            // cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
+            // cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+            // cy.get(EMPTY_RESULTS_ID).should("be.visible");
+            cy.get(SEARCH_INPUT_ID).type(data[0].title);
+            cy.get(`@firstSelectItem`)
+                .should("not.have.class", FOCUSED_OPTION_CLASS)
+                .and("contain.text", data[0].title);
+            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+            cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
+            cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
+            cy.get(SEARCH_INPUT_ID).realPress("Enter");
+            cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
+            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+        });
+    });
+
+    describe("Guidelines Section", () => {
+        it("displays all guidelines when query is empty", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(BACK_BUTTON_ID).should("not.exist");
+            cy.get(ACTION_MENU_ID).contains(GUIDELINE_TITLE).click();
+            cy.get(MENU_ITEM).should("have.length", 1).and("have.text", GUIDELINE_TITLE);
+            cy.get(SELECT_SECTION_ID).children().should("have.length", guidelineSection.items.length);
+        });
+
+        it("shows loading animation and loads results", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(ACTION_MENU_ID).contains(GUIDELINE_TITLE).click({ waitForAnimations: true });
+            cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+            cy.get(LOADER_ID).should("exist");
+            cy.get(RESULTS_LIST_ID)
+                .children()
+                .should("have.length", filterItems(FIRST_GUIDELINE_TITLE, guidelineSection.items).length);
+        });
+
+        it("searches the same query when switching from default view to guidelines view", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+            cy.get(ACTION_MENU_ID).contains(GUIDELINE_TITLE).click({ waitForAnimations: true });
+            cy.get(LOADER_ID).should("exist");
+            cy.get(RESULTS_LIST_ID)
+                .children()
+                .should("have.length", filterItems(FIRST_GUIDELINE_TITLE, guidelineSection.items).length);
+        });
+
+        it("searches the same query when switching from guidelines view to default view", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(ACTION_MENU_ID).contains(GUIDELINE_TITLE).click({ waitForAnimations: true });
+            cy.get(LOADER_ID).should("exist");
+            cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+            cy.get(MENU_ITEM).click();
+            cy.get(LOADER_ID).should("exist");
+            cy.get(RESULTS_LIST_ID)
+                .children()
+                .should("have.length", filterItems(FIRST_GUIDELINE_TITLE, guidelineSection.items).length);
+        });
+
+        it("selects first item", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(ACTION_MENU_ID).contains(GUIDELINE_TITLE).click({ waitForAnimations: true });
+            cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_GUIDELINE_TITLE);
+            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+
+            cy.get("@onLinkChange").should("be.calledOnce");
+        });
+
+        it("does not display a custom link", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(ACTION_MENU_ID).contains(GUIDELINE_TITLE).click({ waitForAnimations: true });
+            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+            cy.get(EMPTY_RESULTS_ID).should("exist");
+        });
+
+        it("repopulates default view with recent queries when selected", () => {
+            localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(SELECT_SECTION_ID)
+                .first()
+                .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
+            cy.get(ACTION_MENU_ID).contains(GUIDELINE_TITLE).click({ waitForAnimations: true });
+            cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+            cy.get("@firstSelectItem").click();
+            cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_GUIDELINE_TITLE);
+            cy.get(SELECT_SECTION_ID).should("not.exist");
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(`${SELECT_SECTION_ID} > li`).first().should("contain", FIRST_GUIDELINE_TITLE);
+            cy.get(`${SELECT_SECTION_ID} > li`)
+                .eq(1)
+                .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
+        });
+
+        it.only("can be navigated to by keyboard", () => {
+            mount(getLinkChooserComponent());
+            cy.window().focus();
+            cy.get("body").realPress("Tab");
+            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+            cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", GUIDELINE_TITLE);
+            cy.get(SEARCH_INPUT_ID).realPress("Enter");
+            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+            cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
+            cy.get("@firstSelectItem").should("contain.text", FIRST_GUIDELINE_TITLE);
+            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+            cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
+            cy.get(SEARCH_INPUT_ID).realPress("Enter");
+            cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_GUIDELINE_TITLE);
+            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+        });
+    });
+});

--- a/src/components/LinkChooser/LinkChooser.spec.tsx
+++ b/src/components/LinkChooser/LinkChooser.spec.tsx
@@ -1,727 +1,727 @@
-/* (c) Copyright Frontify Ltd., all rights reserved. */
-
-import React from "react";
-import { mount } from "@cypress/react";
-import { LinkChooser, QUERIES_STORAGE_KEY } from "./LinkChooser";
-import { MenuItemContentSize } from "@components/MenuItem/MenuItemContent";
-import { SelectionIndicatorIcon } from "@components/MenuItem/MenuItem";
-import { LinkChooserProps, SearchResult, validationClassMap } from "./types";
-import { data } from "./mock/data";
-import { templates } from "./mock/templates";
-import { doesContainSubstring } from "./utils/helpers";
-import { Validation } from "@components/TextInput";
-import { guidelines } from "./mock/guidelines";
-
-const LINK_CHOOSER_ID = "[data-test-id=link-chooser]";
-const SEARCH_WRAPPER_ID = "[data-test-id=link-chooser-search-wrapper]";
-const EMPTY_RESULTS_ID = "[data-test-id=link-chooser-empty-results]";
-const LOADER_ID = "[data-test-id=link-chooser-loader]";
-const ERROR_ID = "[data-test-id=link-chooser-error]";
-const SEARCH_INPUT_ID = "[data-test-id=link-chooser-search-input]";
-const PREVIEW_ICON_ID = "[data-test-id=link-chooser-preview-icon]";
-const COPY_ICON_ID = "[data-test-id=link-chooser-copy-icon]";
-const CLEAR_ICON_ID = "[data-test-id=link-chooser-clear-icon]";
-const SELECT_SECTION_ID = "[data-test-id=link-chooser-select-section]";
-const RESULTS_LIST_ID = "[data-test-id=link-chooser-results-list]";
-const ACTION_MENU_ID = "[data-test-id=link-chooser-action-menu]";
-const BACK_BUTTON_ID = "[data-test-id=link-chooser-back-button]";
-const NEW_TAB_ID = "[data-test-id=link-chooser-new-tab]";
-const CHECKBOX_LABEL_ID = "[data-test-id=input-label]";
-const DROPDOWN_WRAPPER_ID = "[data-test-id=link-chooser-dropdown]";
-const DECORATOR_ICON_ID = "[data-test-id=link-chooser-decorator-icon]";
-const LABEL_ID = "[data-test-id='link-chooser-label']";
-const REQUIRED_ID = "[data-test-id='link-chooser-label-required']";
-const MENU_ITEM = "[data-test-id='link-chooser-navigation-menu-item']";
-
-const DEFAULT_TIMEOUT = 100;
-const CUSTOM_QUERY = "Custom link";
-const SELECTED_CLASS = "tw-text-violet-60";
-const FOCUSED_OPTION_CLASS = "tw-bg-black-0";
-
-const PREFILLED_LOCAL_STORAGE = [
-    {
-        id: "10",
-        title: "Malaya Poster",
-        subtitle: "UNICEF Social Campaign",
-        link: "",
-        icon: "TEMPLATE",
-        size: "Large",
-        selectionIndicator: "None",
-    },
-    {
-        id: "custom-link",
-        title: "www.frontify.com",
-        link: "www.frontify.com",
-        icon: "LINK",
-        size: "Large",
-        selectionIndicator: "None",
-    },
-    {
-        id: "4",
-        title: '"www.website.com"',
-        link: "https://www.frontify.com/en/digital-and-print-templates/",
-        icon: "EXTERNAL",
-        size: "Large",
-        selectionIndicator: "None",
-    },
-    {
-        id: "11",
-        preview:
-            "https://images.frontify.test/s3/frontify-dev-files/eyJwYXRoIjoibXNpcmljXC9hY2NvdW50c1wvYzRcLzFcL3Byb2plY3RzXC8yXC9hc3NldHNcL2MyXC8xMlwvYTFkYzA0YTJkYmQwZTkxMTRlOGM2ODQzMWVmMjU5OTMtMTYzNDMwMTQ1MS5qcGcifQ:msiric:MLRtZYQCaEyWpPqgpGbA6P20PDgvagyoowNOllXgoCk?width=2400&height={height}",
-        title: "Brand Business Card",
-        subtitle: "Corporate Library",
-        link: "#",
-        icon: "TEMPLATE",
-        size: "Large",
-        selectionIndicator: "None",
-    },
-    {
-        id: "1",
-        title: "Brand listening - A Memoir",
-        subtitle: "Guideline XYZ",
-        link: "https://www.frontify.com",
-        icon: "DOCUMENT",
-        size: "Large",
-        selectionIndicator: "None",
-    },
-];
-
-const filterItems = (query: string, results: SearchResult[]): SearchResult[] =>
-    results.filter((item) => doesContainSubstring(item.title, query));
-
-const getLinkChooserComponent = (overwriteProps?: Partial<LinkChooserProps>, returnError = false) => {
-    const getGlobalByQuery = (query: string): Promise<SearchResult[]> => {
-        return new Promise((resolve, reject) =>
-            setTimeout(() => {
-                returnError
-                    ? reject()
-                    : resolve(
-                          filterItems(query, data).map((item) => ({
-                              ...item,
-                              size: MenuItemContentSize.Large,
-                              selectionIndicator: SelectionIndicatorIcon.None,
-                          })),
-                      );
-            }, DEFAULT_TIMEOUT),
-        );
-    };
-
-    const getTemplatesByQueryMock = (query: string): Promise<SearchResult[]> => {
-        return new Promise((resolve, reject) =>
-            setTimeout(() => {
-                returnError ? reject() : resolve(filterItems(query, templates));
-            }, DEFAULT_TIMEOUT),
-        );
-    };
-
-    const getGuidelinesByQueryMock = (query: string): Promise<SearchResult[]> => {
-        return new Promise((resolve, reject) =>
-            setTimeout(() => {
-                returnError ? reject() : resolve(filterItems(query, guidelines));
-            }, DEFAULT_TIMEOUT),
-        );
-    };
-
-    const onLinkChange = cy.stub().as("onLinkChange");
-    const onOpenInNewTabChange = cy.stub().as("onOpenInNewTabChange");
-    const clipboardOptions = { writeText: cy.stub().as("clipboardOptions") };
-    const openPreview = cy.stub().as("openPreview");
-
-    return (
-        <LinkChooser
-            getGlobalByQuery={getGlobalByQuery}
-            getTemplatesByQuery={getTemplatesByQueryMock}
-            getGuidelinesByQuery={getGuidelinesByQueryMock}
-            clipboardOptions={clipboardOptions}
-            openPreview={openPreview}
-            onLinkChange={onLinkChange}
-            onOpenInNewTabChange={onOpenInNewTabChange}
-            openInNewTab={false}
-            {...overwriteProps}
-        />
-    );
-};
-
-describe("LinkChooser Component", () => {
-    it("renders correctly", () => {
-        mount(getLinkChooserComponent());
-
-        cy.get(LINK_CHOOSER_ID).should("be.visible");
-    });
-
-    describe("Input", () => {
-        it("renders input props Label", () => {
-            const label = "LABEL";
-            const placeholder = "PLACEHOLDER";
-            mount(getLinkChooserComponent({ label, placeholder, required: true, validation: Validation.Error }));
-
-            cy.get(LABEL_ID).should("contain", label);
-            cy.get(REQUIRED_ID).should("have.text", "*");
-            cy.get(SEARCH_INPUT_ID).invoke("attr", "placeholder").should("equal", placeholder);
-            cy.get(SEARCH_WRAPPER_ID).should("have.class", validationClassMap[Validation.Error]);
-        });
-
-        it("disables input and checkbox", () => {
-            mount(getLinkChooserComponent({ disabled: true }));
-
-            cy.get(SEARCH_INPUT_ID).should("be.disabled");
-            cy.get("input[type='checkbox']").should("be.disabled");
-        });
-    });
-
-    describe("Empty localStorage", () => {
-        beforeEach(() => {
-            localStorage.removeItem(QUERIES_STORAGE_KEY);
-        });
-
-        it("displays empty results on click", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SELECT_SECTION_ID).should("not.exist");
-            cy.get(PREVIEW_ICON_ID).should("not.exist");
-            cy.get(COPY_ICON_ID).should("not.exist");
-            cy.get(CLEAR_ICON_ID).should("not.exist");
-            cy.get(EMPTY_RESULTS_ID).should("exist");
-        });
-
-        it("opens dropdown on focus and/or typing, closes on escape", () => {
-            mount(getLinkChooserComponent());
-            cy.window().focus();
-            cy.get("body").realPress("Tab");
-            cy.get(SEARCH_INPUT_ID).should("be.focused");
-            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-            cy.get(SEARCH_INPUT_ID).realPress("Escape");
-            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-            cy.get(SEARCH_INPUT_ID).type(" ");
-            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-        });
-
-        it("shows loading animation and loads results", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(LOADER_ID).should("exist");
-            cy.get(SELECT_SECTION_ID)
-                .children()
-                .should("have.length", filterItems(data[0].title, data).length + 1);
-        });
-
-        it("selects first item", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
-            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-            cy.get("@onLinkChange").should("be.calledOnce");
-        });
-
-        it("opens in new tab", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(`${NEW_TAB_ID} ${CHECKBOX_LABEL_ID}`).click();
-            cy.get("@onOpenInNewTabChange").should("be.calledOnce");
-        });
-
-        it("opens preview", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(PREVIEW_ICON_ID).click();
-            cy.get("@openPreview").should("be.calledOnce");
-        });
-
-        it("copies to clipboard", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(COPY_ICON_ID).click();
-            cy.get("@clipboardOptions").should("be.calledOnce");
-        });
-
-        it("clears the search input", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(CLEAR_ICON_ID).click();
-            cy.get("@onLinkChange").should("be.called");
-            cy.get(SEARCH_INPUT_ID).should("be.empty");
-        });
-
-        it("displays a custom link", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get("@onLinkChange").should("be.called");
-            cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
-        });
-
-        it("hides dropdown on blur", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(DROPDOWN_WRAPPER_ID).should("exist");
-            cy.get(SEARCH_INPUT_ID).blur();
-            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-        });
-
-        it("adds selected item to local storage", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(CLEAR_ICON_ID).click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SELECT_SECTION_ID).children().should("have.length", 1);
-        });
-
-        it("interrupts the fetching phase and selects the query as custom link", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-            cy.get(SEARCH_INPUT_ID).blur();
-            cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(`${SELECT_SECTION_ID} > li > div`)
-                .eq(0)
-                .should(($container) => {
-                    expect($container).to.have.css("font-weight", "500");
-                });
-        });
-
-        it("adds a new custom link to local storage each time, unless matching text", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type("1");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 2);
-            cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}1`);
-            cy.get(SEARCH_INPUT_ID).type("{Backspace}2");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 3);
-            cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}2`);
-            cy.get(SEARCH_INPUT_ID).type("{Backspace}1");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 3);
-            cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}1`);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(1).should("contain.text", `${CUSTOM_QUERY}2`);
-        });
-
-        it("resumes fetching when dropdown opens if the fetching phase was previously interrupted", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get("body").click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(LOADER_ID).should("exist");
-            cy.get(SELECT_SECTION_ID)
-                .children()
-                .should("have.length", filterItems(data[0].title, data).length + 1);
-        });
-
-        it("does not resume fetching when dropdown opens if the fetching phase was previously resolved", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get("body").click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(LOADER_ID).should("not.exist");
-        });
-
-        it("selects existing document and reselects it on interrupt if the titles match", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type("{backspace}");
-            cy.get(SEARCH_INPUT_ID).type(data[0].title[data[0].title.length - 1]);
-            cy.get("body").click();
-            cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
-            cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconDocument");
-        });
-
-        it("selects existing document and does not reselect it on interrupt if the titles do not match", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).clear();
-            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-            cy.get("body").click();
-            cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
-            cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconLink");
-        });
-
-        it("Creates and selects a custom link if enter pressed and no item is focused, even when loading", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-            cy.get(DROPDOWN_WRAPPER_ID).should("exist");
-            cy.get(LOADER_ID).should("be.visible");
-            cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
-            cy.get(SEARCH_INPUT_ID).realPress("Enter");
-            cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
-            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-            cy.get(DROPDOWN_WRAPPER_ID).should("exist");
-            cy.get(`${SELECT_SECTION_ID} > li > div`)
-                .eq(0)
-                .should(($container) => {
-                    expect($container).to.have.css("font-weight", "500");
-                });
-        });
-
-        it("resets selection if input is empty", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconDocument");
-            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-            cy.get("@onLinkChange").should("be.calledOnce");
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).clear();
-            cy.get("@onLinkChange").should("be.calledTwice");
-            cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
-        });
-
-        it("displays error message when fetching fails", () => {
-            mount(getLinkChooserComponent({}, true));
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(SELECT_SECTION_ID).should("not.exist");
-            cy.get(ERROR_ID).should("exist");
-        });
-    });
-
-    describe("Filled localStorage", () => {
-        beforeEach(() => {
-            localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
-        });
-
-        it("displays recent queries on click", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(PREVIEW_ICON_ID).should("not.exist");
-            cy.get(COPY_ICON_ID).should("not.exist");
-            cy.get(CLEAR_ICON_ID).should("not.exist");
-            cy.get(EMPTY_RESULTS_ID).should("not.exist");
-            cy.get(SELECT_SECTION_ID)
-                .children()
-                .should("have.length", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null").length);
-        });
-
-        it("replaces first item with the most recent selection", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").should(
-                "contain",
-                JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title,
-            );
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(3).as("thirdSelectItem");
-            cy.get("@thirdSelectItem").click();
-            cy.get(CLEAR_ICON_ID).click();
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("newFirstSelectItem");
-            cy.get("@newFirstSelectItem").should(
-                "contain",
-                JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[3].title,
-            );
-        });
-
-        it("replaces local storage results with search results on search input change", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(LOADER_ID).should("exist");
-            cy.get(SELECT_SECTION_ID)
-                .children()
-                .should("have.length", filterItems(data[0].title, data).length + 1);
-        });
-    });
-
-    describe("Templates section", () => {
-        it("displays all templates when query is empty", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(BACK_BUTTON_ID).should("not.exist");
-            cy.get(ACTION_MENU_ID).contains("Templates").click();
-            cy.get(MENU_ITEM).should("have.length", 1).and("have.text", "templates");
-            cy.get(SELECT_SECTION_ID).children().should("have.length", templates.length);
-        });
-
-        it("shows loading animation and loads results", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-            cy.get(SEARCH_INPUT_ID).type(templates[0].title);
-            cy.get(LOADER_ID).should("exist");
-            cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(templates[0].title, data).length);
-        });
-
-        it("searches the same query when switching from default view to templates view", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(templates[0].title);
-            cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-            cy.get(LOADER_ID).should("exist");
-            cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(templates[0].title, data).length);
-        });
-
-        it("searches the same query when switching from templates view to default view", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-            cy.get(LOADER_ID).should("exist");
-            cy.get(SEARCH_INPUT_ID).type(templates[0].title);
-            cy.get(MENU_ITEM).click();
-            cy.get(LOADER_ID).should("exist");
-            cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(templates[0].title, data).length);
-        });
-
-        it("selects first item", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-            cy.get(SEARCH_INPUT_ID).type(templates[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_INPUT_ID).should("have.value", templates[0].title);
-
-            cy.get("@onLinkChange").should("be.calledOnce");
-        });
-
-        it("does not display a custom link", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-            cy.get(EMPTY_RESULTS_ID).should("exist");
-        });
-
-        it("repopulates default view with recent queries when selected", () => {
-            localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SELECT_SECTION_ID)
-                .first()
-                .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
-            cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
-            cy.get(SEARCH_INPUT_ID).type(templates[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_INPUT_ID).should("have.value", templates[0].title);
-            cy.get(SELECT_SECTION_ID).should("not.exist");
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(`${SELECT_SECTION_ID} > li`).first().should("contain", templates[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`)
-                .eq(1)
-                .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
-        });
-
-        it("can be navigated to by keyboard", () => {
-            mount(getLinkChooserComponent());
-            cy.window().focus();
-            cy.get("body").realPress("Tab");
-            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-            cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-            cy.get(MENU_ITEM).first().should("not.have.class", FOCUSED_OPTION_CLASS);
-            cy.get(MENU_ITEM).eq(1).should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "Templates");
-            cy.get(SEARCH_INPUT_ID).realPress("Enter");
-            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-            cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
-            cy.get("@firstSelectItem").should("contain.text", templates[0].title);
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-            cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "templates");
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-            cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowUp");
-            cy.get(`@firstSelectItem`).should("not.have.class", FOCUSED_OPTION_CLASS);
-            cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
-            cy.get(SEARCH_INPUT_ID).realPress("Enter");
-            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-            cy.get(EMPTY_RESULTS_ID).should("be.visible");
-            cy.get(SEARCH_INPUT_ID).type(data[0].title);
-            cy.get(`@firstSelectItem`)
-                .should("not.have.class", FOCUSED_OPTION_CLASS)
-                .and("contain.text", data[0].title);
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-            cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
-            cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
-            cy.get(SEARCH_INPUT_ID).realPress("Enter");
-            cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
-            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-        });
-    });
-
-    describe("Guidelines Section", () => {
-        it("displays all guidelines when query is empty", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(BACK_BUTTON_ID).should("not.exist");
-            cy.get(ACTION_MENU_ID).contains("Guidelines").click();
-            cy.get(MENU_ITEM).should("have.length", 1).and("have.text", "guidelines");
-            cy.get(SELECT_SECTION_ID).children().should("have.length", guidelines.length);
-        });
-
-        it("shows loading animation and loads results", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-            cy.get(SEARCH_INPUT_ID).type(guidelines[0].title);
-            cy.get(LOADER_ID).should("exist");
-            cy.get(RESULTS_LIST_ID)
-                .children()
-                .should("have.length", filterItems(guidelines[0].title, guidelines).length);
-        });
-
-        it("searches the same query when switching from default view to guidelines view", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SEARCH_INPUT_ID).type(guidelines[0].title);
-            cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-            cy.get(LOADER_ID).should("exist");
-            cy.get(RESULTS_LIST_ID)
-                .children()
-                .should("have.length", filterItems(guidelines[0].title, guidelines).length);
-        });
-
-        it("searches the same query when switching from guidelines view to default view", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-            cy.get(LOADER_ID).should("exist");
-            cy.get(SEARCH_INPUT_ID).type(guidelines[0].title);
-            cy.get(MENU_ITEM).click();
-            cy.get(LOADER_ID).should("exist");
-            cy.get(RESULTS_LIST_ID)
-                .children()
-                .should("have.length", filterItems(guidelines[0].title, guidelines).length);
-        });
-
-        it("selects first item", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-            cy.get(SEARCH_INPUT_ID).type(guidelines[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_INPUT_ID).should("have.value", guidelines[0].title);
-            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-
-            cy.get("@onLinkChange").should("be.calledOnce");
-        });
-
-        it("does not display a custom link", () => {
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-            cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
-            cy.get(EMPTY_RESULTS_ID).should("exist");
-        });
-
-        it("repopulates default view with recent queries when selected", () => {
-            localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
-            mount(getLinkChooserComponent());
-
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(SELECT_SECTION_ID)
-                .first()
-                .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
-            cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
-            cy.get(SEARCH_INPUT_ID).type(guidelines[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
-            cy.get("@firstSelectItem").click();
-            cy.get(SEARCH_INPUT_ID).should("have.value", guidelines[0].title);
-            cy.get(SELECT_SECTION_ID).should("not.exist");
-            cy.get(SEARCH_WRAPPER_ID).click();
-            cy.get(`${SELECT_SECTION_ID} > li`).first().should("contain", guidelines[0].title);
-            cy.get(`${SELECT_SECTION_ID} > li`)
-                .eq(1)
-                .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
-        });
-
-        it("can be navigated to by keyboard", () => {
-            mount(getLinkChooserComponent());
-            cy.window().focus();
-            cy.get("body").realPress("Tab");
-            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-            cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "Guidelines");
-            cy.get(SEARCH_INPUT_ID).realPress("Enter");
-            cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-            cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
-            cy.get("@firstSelectItem").should("contain.text", guidelines[0].title);
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-            cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "guidelines");
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-            cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
-            cy.get(SEARCH_INPUT_ID).realPress("Enter");
-            cy.get(SEARCH_INPUT_ID).should("have.value", guidelines[0].title);
-            cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
-            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
-        });
-    });
-});
+// /* (c) Copyright Frontify Ltd., all rights reserved. */
+
+// import { SelectionIndicatorIcon } from "@components/MenuItem/MenuItem";
+// import { MenuItemContentSize } from "@components/MenuItem/MenuItemContent";
+// import { Validation } from "@components/TextInput";
+// import { mount } from "@cypress/react";
+// import React from "react";
+// import { LinkChooser, QUERIES_STORAGE_KEY } from "./LinkChooser";
+// import { data } from "./mock/data";
+// import { guidelineSection } from "./mock/guidelines";
+// import { templateSection } from "./mock/templates";
+// import { LinkChooserProps, SearchResult, validationClassMap } from "./types";
+// import { doesContainSubstring } from "./utils/helpers";
+
+// const LINK_CHOOSER_ID = "[data-test-id=link-chooser]";
+// const SEARCH_WRAPPER_ID = "[data-test-id=link-chooser-search-wrapper]";
+// const EMPTY_RESULTS_ID = "[data-test-id=link-chooser-empty-results]";
+// const LOADER_ID = "[data-test-id=link-chooser-loader]";
+// const ERROR_ID = "[data-test-id=link-chooser-error]";
+// const SEARCH_INPUT_ID = "[data-test-id=link-chooser-search-input]";
+// const PREVIEW_ICON_ID = "[data-test-id=link-chooser-preview-icon]";
+// const COPY_ICON_ID = "[data-test-id=link-chooser-copy-icon]";
+// const CLEAR_ICON_ID = "[data-test-id=link-chooser-clear-icon]";
+// const SELECT_SECTION_ID = "[data-test-id=link-chooser-select-section]";
+// const RESULTS_LIST_ID = "[data-test-id=link-chooser-results-list]";
+// const ACTION_MENU_ID = "[data-test-id=link-chooser-action-menu]";
+// const BACK_BUTTON_ID = "[data-test-id=link-chooser-back-button]";
+// const NEW_TAB_ID = "[data-test-id=link-chooser-new-tab]";
+// const CHECKBOX_LABEL_ID = "[data-test-id=input-label]";
+// const DROPDOWN_WRAPPER_ID = "[data-test-id=link-chooser-dropdown]";
+// const DECORATOR_ICON_ID = "[data-test-id=link-chooser-decorator-icon]";
+// const LABEL_ID = "[data-test-id='link-chooser-label']";
+// const REQUIRED_ID = "[data-test-id='link-chooser-label-required']";
+// const MENU_ITEM = "[data-test-id='link-chooser-navigation-menu-item']";
+
+// const DEFAULT_TIMEOUT = 100;
+// const CUSTOM_QUERY = "Custom link";
+// const SELECTED_CLASS = "tw-text-violet-60";
+// const FOCUSED_OPTION_CLASS = "tw-bg-black-0";
+// const FIRST_TEMPLATE_TITLE = templateSection.items[0].title;
+// const FIRST_GUIDELINE_TITLE = guidelineSection.items[0].title;
+
+// const PREFILLED_LOCAL_STORAGE = [
+//     {
+//         id: "10",
+//         title: "Malaya Poster",
+//         subtitle: "UNICEF Social Campaign",
+//         link: "",
+//         icon: "TEMPLATE",
+//         size: "Large",
+//         selectionIndicator: "None",
+//     },
+//     {
+//         id: "custom-link",
+//         title: "www.frontify.com",
+//         link: "www.frontify.com",
+//         icon: "LINK",
+//         size: "Large",
+//         selectionIndicator: "None",
+//     },
+//     {
+//         id: "4",
+//         title: '"www.website.com"',
+//         link: "https://www.frontify.com/en/digital-and-print-templates/",
+//         icon: "EXTERNAL",
+//         size: "Large",
+//         selectionIndicator: "None",
+//     },
+//     {
+//         id: "11",
+//         preview:
+//             "https://images.frontify.test/s3/frontify-dev-files/eyJwYXRoIjoibXNpcmljXC9hY2NvdW50c1wvYzRcLzFcL3Byb2plY3RzXC8yXC9hc3NldHNcL2MyXC8xMlwvYTFkYzA0YTJkYmQwZTkxMTRlOGM2ODQzMWVmMjU5OTMtMTYzNDMwMTQ1MS5qcGcifQ:msiric:MLRtZYQCaEyWpPqgpGbA6P20PDgvagyoowNOllXgoCk?width=2400&height={height}",
+//         title: "Brand Business Card",
+//         subtitle: "Corporate Library",
+//         link: "#",
+//         icon: "TEMPLATE",
+//         size: "Large",
+//         selectionIndicator: "None",
+//     },
+//     {
+//         id: "1",
+//         title: "Brand listening - A Memoir",
+//         subtitle: "Guideline XYZ",
+//         link: "https://www.frontify.com",
+//         icon: "DOCUMENT",
+//         size: "Large",
+//         selectionIndicator: "None",
+//     },
+// ];
+
+// const filterItems = (query: string, results: SearchResult[]): SearchResult[] =>
+//     results.filter((item) => doesContainSubstring(item.title, query, []));
+
+// const getLinkChooserComponent = (overwriteProps?: Partial<LinkChooserProps>, returnError = false) => {
+//     const getGlobalByQuery = (query: string): Promise<SearchResult[]> => {
+//         return new Promise((resolve, reject) =>
+//             setTimeout(() => {
+//                 returnError
+//                     ? reject()
+//                     : resolve(
+//                           filterItems(query, data).map((item) => ({
+//                               ...item,
+//                               size: MenuItemContentSize.Large,
+//                               selectionIndicator: SelectionIndicatorIcon.None,
+//                           })),
+//                       );
+//             }, DEFAULT_TIMEOUT),
+//         );
+//     };
+
+//     const getTemplatesByQueryMock = (query: string): Promise<SearchResult[]> => {
+//         return new Promise((resolve, reject) =>
+//             setTimeout(() => {
+//                 returnError ? reject() : resolve(filterItems(query, templateSection.items));
+//             }, DEFAULT_TIMEOUT),
+//         );
+//     };
+
+//     const getGuidelinesByQueryMock = (query: string): Promise<SearchResult[]> => {
+//         return new Promise((resolve, reject) =>
+//             setTimeout(() => {
+//                 returnError ? reject() : resolve(filterItems(query, guidelineSection.items));
+//             }, DEFAULT_TIMEOUT),
+//         );
+//     };
+
+//     const onLinkChange = cy.stub().as("onLinkChange");
+//     const onOpenInNewTabChange = cy.stub().as("onOpenInNewTabChange");
+//     const clipboardOptions = { writeText: cy.stub().as("clipboardOptions") };
+//     const openPreview = cy.stub().as("openPreview");
+
+//     return (
+//         <LinkChooser
+//             getGlobalByQuery={getGlobalByQuery}
+//             clipboardOptions={clipboardOptions}
+//             openPreview={openPreview}
+//             onLinkChange={onLinkChange}
+//             onOpenInNewTabChange={onOpenInNewTabChange}
+//             openInNewTab={false}
+//             {...overwriteProps}
+//         />
+//     );
+// };
+
+// describe("LinkChooser Component", () => {
+//     it("renders correctly", () => {
+//         mount(getLinkChooserComponent());
+
+//         cy.get(LINK_CHOOSER_ID).should("be.visible");
+//     });
+
+//     describe("Input", () => {
+//         it("renders input props Label", () => {
+//             const label = "LABEL";
+//             const placeholder = "PLACEHOLDER";
+//             mount(getLinkChooserComponent({ label, placeholder, required: true, validation: Validation.Error }));
+
+//             cy.get(LABEL_ID).should("contain", label);
+//             cy.get(REQUIRED_ID).should("have.text", "*");
+//             cy.get(SEARCH_INPUT_ID).invoke("attr", "placeholder").should("equal", placeholder);
+//             cy.get(SEARCH_WRAPPER_ID).should("have.class", validationClassMap[Validation.Error]);
+//         });
+
+//         it("disables input and checkbox", () => {
+//             mount(getLinkChooserComponent({ disabled: true }));
+
+//             cy.get(SEARCH_INPUT_ID).should("be.disabled");
+//             cy.get("input[type='checkbox']").should("be.disabled");
+//         });
+//     });
+
+//     describe("Empty localStorage", () => {
+//         beforeEach(() => {
+//             localStorage.removeItem(QUERIES_STORAGE_KEY);
+//         });
+
+//         it("displays empty results on click", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SELECT_SECTION_ID).should("not.exist");
+//             cy.get(PREVIEW_ICON_ID).should("not.exist");
+//             cy.get(COPY_ICON_ID).should("not.exist");
+//             cy.get(CLEAR_ICON_ID).should("not.exist");
+//             cy.get(EMPTY_RESULTS_ID).should("exist");
+//         });
+
+//         it("opens dropdown on focus and/or typing, closes on escape", () => {
+//             mount(getLinkChooserComponent());
+//             cy.window().focus();
+//             cy.get("body").realPress("Tab");
+//             cy.get(SEARCH_INPUT_ID).should("be.focused");
+//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+//             cy.get(SEARCH_INPUT_ID).realPress("Escape");
+//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+//             cy.get(SEARCH_INPUT_ID).type(" ");
+//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+//         });
+
+//         it("shows loading animation and loads results", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(SELECT_SECTION_ID)
+//                 .children()
+//                 .should("have.length", filterItems(data[0].title, data).length + 1);
+//         });
+
+//         it("selects first item", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
+//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+//             cy.get("@onLinkChange").should("be.calledOnce");
+//         });
+
+//         it("opens in new tab", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(`${NEW_TAB_ID} ${CHECKBOX_LABEL_ID}`).click();
+//             cy.get("@onOpenInNewTabChange").should("be.calledOnce");
+//         });
+
+//         it("opens preview", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(PREVIEW_ICON_ID).click();
+//             cy.get("@openPreview").should("be.calledOnce");
+//         });
+
+//         it("copies to clipboard", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(COPY_ICON_ID).click();
+//             cy.get("@clipboardOptions").should("be.calledOnce");
+//         });
+
+//         it("clears the search input", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(CLEAR_ICON_ID).click();
+//             cy.get("@onLinkChange").should("be.called");
+//             cy.get(SEARCH_INPUT_ID).should("be.empty");
+//         });
+
+//         it("displays a custom link", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get("@onLinkChange").should("be.called");
+//             cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
+//         });
+
+//         it("hides dropdown on blur", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(DROPDOWN_WRAPPER_ID).should("exist");
+//             cy.get(SEARCH_INPUT_ID).blur();
+//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+//         });
+
+//         it("adds selected item to local storage", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(CLEAR_ICON_ID).click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SELECT_SECTION_ID).children().should("have.length", 1);
+//         });
+
+//         it("interrupts the fetching phase and selects the query as custom link", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+//             cy.get(SEARCH_INPUT_ID).blur();
+//             cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(`${SELECT_SECTION_ID} > li > div`)
+//                 .eq(0)
+//                 .should(($container) => {
+//                     expect($container).to.have.css("font-weight", "500");
+//                 });
+//         });
+
+//         it("adds a new custom link to local storage each time, unless matching text", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type("1");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 2);
+//             cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}1`);
+//             cy.get(SEARCH_INPUT_ID).type("{Backspace}2");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 3);
+//             cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}2`);
+//             cy.get(SEARCH_INPUT_ID).type("{Backspace}1");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(`${SELECT_SECTION_ID} > li`).should("have.length", 3);
+//             cy.get("@firstSelectItem").should("contain.text", `${CUSTOM_QUERY}1`);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(1).should("contain.text", `${CUSTOM_QUERY}2`);
+//         });
+
+//         it("resumes fetching when dropdown opens if the fetching phase was previously interrupted", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get("body").click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(SELECT_SECTION_ID)
+//                 .children()
+//                 .should("have.length", filterItems(data[0].title, data).length + 1);
+//         });
+
+//         it("does not resume fetching when dropdown opens if the fetching phase was previously resolved", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get("body").click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(LOADER_ID).should("not.exist");
+//         });
+
+//         it("selects existing document and reselects it on interrupt if the titles match", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type("{backspace}");
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title[data[0].title.length - 1]);
+//             cy.get("body").click();
+//             cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
+//             cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconDocument");
+//         });
+
+//         it("selects existing document and does not reselect it on interrupt if the titles do not match", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).clear();
+//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+//             cy.get("body").click();
+//             cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
+//             cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconLink");
+//         });
+
+//         it("Creates and selects a custom link if enter pressed and no item is focused, even when loading", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+//             cy.get(DROPDOWN_WRAPPER_ID).should("exist");
+//             cy.get(LOADER_ID).should("be.visible");
+//             cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
+//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
+//             cy.get(SEARCH_INPUT_ID).should("have.value", CUSTOM_QUERY);
+//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+//             cy.get(DROPDOWN_WRAPPER_ID).should("exist");
+//             cy.get(`${SELECT_SECTION_ID} > li > div`)
+//                 .eq(0)
+//                 .should(($container) => {
+//                     expect($container).to.have.css("font-weight", "500");
+//                 });
+//         });
+
+//         it("resets selection if input is empty", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(`${DECORATOR_ICON_ID} > svg`).invoke("attr", "name").should("eq", "IconDocument");
+//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+//             cy.get("@onLinkChange").should("be.calledOnce");
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).clear();
+//             cy.get("@onLinkChange").should("be.calledTwice");
+//             cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
+//         });
+
+//         it("displays error message when fetching fails", () => {
+//             mount(getLinkChooserComponent({}, true));
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(SELECT_SECTION_ID).should("not.exist");
+//             cy.get(ERROR_ID).should("exist");
+//         });
+//     });
+
+//     describe("Filled localStorage", () => {
+//         beforeEach(() => {
+//             localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
+//         });
+
+//         it("displays recent queries on click", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(PREVIEW_ICON_ID).should("not.exist");
+//             cy.get(COPY_ICON_ID).should("not.exist");
+//             cy.get(CLEAR_ICON_ID).should("not.exist");
+//             cy.get(EMPTY_RESULTS_ID).should("not.exist");
+//             cy.get(SELECT_SECTION_ID)
+//                 .children()
+//                 .should("have.length", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null").length);
+//         });
+
+//         it("replaces first item with the most recent selection", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").should(
+//                 "contain",
+//                 JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title,
+//             );
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(3).as("thirdSelectItem");
+//             cy.get("@thirdSelectItem").click();
+//             cy.get(CLEAR_ICON_ID).click();
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("newFirstSelectItem");
+//             cy.get("@newFirstSelectItem").should(
+//                 "contain",
+//                 JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[3].title,
+//             );
+//         });
+
+//         it("replaces local storage results with search results on search input change", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(SELECT_SECTION_ID)
+//                 .children()
+//                 .should("have.length", filterItems(data[0].title, data).length + 1);
+//         });
+//     });
+
+//     describe("Templates section", () => {
+//         it("displays all templates when query is empty", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(BACK_BUTTON_ID).should("not.exist");
+//             cy.get(ACTION_MENU_ID).contains("Templates").click();
+//             cy.get(MENU_ITEM).should("have.length", 1).and("have.text", "templates");
+//             cy.get(SELECT_SECTION_ID).children().should("have.length", templateSection.items.length);
+//         });
+
+//         it("shows loading animation and loads results", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(FIRST_TEMPLATE_TITLE, data).length);
+//         });
+
+//         it("searches the same query when switching from default view to templates view", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(FIRST_TEMPLATE_TITLE, data).length);
+//         });
+
+//         it("searches the same query when switching from templates view to default view", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+//             cy.get(MENU_ITEM).click();
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(RESULTS_LIST_ID).children().should("have.length", filterItems(FIRST_TEMPLATE_TITLE, data).length);
+//         });
+
+//         it("selects first item", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_TEMPLATE_TITLE);
+
+//             cy.get("@onLinkChange").should("be.calledOnce");
+//         });
+
+//         it("does not display a custom link", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
+//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+//             cy.get(EMPTY_RESULTS_ID).should("exist");
+//         });
+
+//         it("repopulates default view with recent queries when selected", () => {
+//             localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SELECT_SECTION_ID)
+//                 .first()
+//                 .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
+//             cy.get(ACTION_MENU_ID).contains("Templates").click({ waitForAnimations: true });
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_TEMPLATE_TITLE);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_TEMPLATE_TITLE);
+//             cy.get(SELECT_SECTION_ID).should("not.exist");
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(`${SELECT_SECTION_ID} > li`).first().should("contain", FIRST_TEMPLATE_TITLE);
+//             cy.get(`${SELECT_SECTION_ID} > li`)
+//                 .eq(1)
+//                 .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
+//         });
+
+//         it("can be navigated to by keyboard", () => {
+//             mount(getLinkChooserComponent());
+//             cy.window().focus();
+//             cy.get("body").realPress("Tab");
+//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
+//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+//             cy.get(MENU_ITEM).first().should("not.have.class", FOCUSED_OPTION_CLASS);
+//             cy.get(MENU_ITEM).eq(1).should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "Templates");
+//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
+//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+//             cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
+//             cy.get("@firstSelectItem").should("contain.text", FIRST_TEMPLATE_TITLE);
+//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "templates");
+//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+//             cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
+//             cy.get(SEARCH_INPUT_ID).realPress("ArrowUp");
+//             cy.get(`@firstSelectItem`).should("not.have.class", FOCUSED_OPTION_CLASS);
+//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
+//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
+//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+//             cy.get(EMPTY_RESULTS_ID).should("be.visible");
+//             cy.get(SEARCH_INPUT_ID).type(data[0].title);
+//             cy.get(`@firstSelectItem`)
+//                 .should("not.have.class", FOCUSED_OPTION_CLASS)
+//                 .and("contain.text", data[0].title);
+//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+//             cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
+//             cy.get(DECORATOR_ICON_ID).should("not.have.class", SELECTED_CLASS);
+//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
+//             cy.get(SEARCH_INPUT_ID).should("have.value", data[0].title);
+//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+//         });
+//     });
+
+//     describe("Guidelines Section", () => {
+//         it("displays all guidelines when query is empty", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(BACK_BUTTON_ID).should("not.exist");
+//             cy.get(ACTION_MENU_ID).contains("Guidelines").click();
+//             cy.get(MENU_ITEM).should("have.length", 1).and("have.text", "guidelines");
+//             cy.get(SELECT_SECTION_ID).children().should("have.length", guidelineSection.length);
+//         });
+
+//         it("shows loading animation and loads results", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(RESULTS_LIST_ID)
+//                 .children()
+//                 .should("have.length", filterItems(FIRST_GUIDELINE_TITLE, guidelineSection).length);
+//         });
+
+//         it("searches the same query when switching from default view to guidelines view", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(RESULTS_LIST_ID)
+//                 .children()
+//                 .should("have.length", filterItems(FIRST_GUIDELINE_TITLE, guidelineSection).length);
+//         });
+
+//         it("searches the same query when switching from guidelines view to default view", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+//             cy.get(MENU_ITEM).click();
+//             cy.get(LOADER_ID).should("exist");
+//             cy.get(RESULTS_LIST_ID)
+//                 .children()
+//                 .should("have.length", filterItems(FIRST_GUIDELINE_TITLE, guidelineSection).length);
+//         });
+
+//         it("selects first item", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_GUIDELINE_TITLE);
+//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+
+//             cy.get("@onLinkChange").should("be.calledOnce");
+//         });
+
+//         it("does not display a custom link", () => {
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
+//             cy.get(SEARCH_INPUT_ID).type(CUSTOM_QUERY);
+//             cy.get(EMPTY_RESULTS_ID).should("exist");
+//         });
+
+//         it("repopulates default view with recent queries when selected", () => {
+//             localStorage.setItem(QUERIES_STORAGE_KEY, JSON.stringify(PREFILLED_LOCAL_STORAGE));
+//             mount(getLinkChooserComponent());
+
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(SELECT_SECTION_ID)
+//                 .first()
+//                 .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
+//             cy.get(ACTION_MENU_ID).contains("Guidelines").click({ waitForAnimations: true });
+//             cy.get(SEARCH_INPUT_ID).type(FIRST_GUIDELINE_TITLE);
+//             cy.get(`${SELECT_SECTION_ID} > li`).eq(0).as("firstSelectItem");
+//             cy.get("@firstSelectItem").click();
+//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_GUIDELINE_TITLE);
+//             cy.get(SELECT_SECTION_ID).should("not.exist");
+//             cy.get(SEARCH_WRAPPER_ID).click();
+//             cy.get(`${SELECT_SECTION_ID} > li`).first().should("contain", FIRST_GUIDELINE_TITLE);
+//             cy.get(`${SELECT_SECTION_ID} > li`)
+//                 .eq(1)
+//                 .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
+//         });
+
+//         it("can be navigated to by keyboard", () => {
+//             mount(getLinkChooserComponent());
+//             cy.window().focus();
+//             cy.get("body").realPress("Tab");
+//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "Guidelines");
+//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
+//             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+//             cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
+//             cy.get("@firstSelectItem").should("contain.text", FIRST_GUIDELINE_TITLE);
+//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+//             cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", "guidelines");
+//             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
+//             cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
+//             cy.get(SEARCH_INPUT_ID).realPress("Enter");
+//             cy.get(SEARCH_INPUT_ID).should("have.value", FIRST_GUIDELINE_TITLE);
+//             cy.get(DECORATOR_ICON_ID).should("have.class", SELECTED_CLASS);
+//             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+//         });
+//     });
+// });

--- a/src/components/LinkChooser/LinkChooser.stories.tsx
+++ b/src/components/LinkChooser/LinkChooser.stories.tsx
@@ -5,8 +5,8 @@ import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
 import { LinkChooser as LinkChooserComponent } from "./LinkChooser";
 import { data } from "./mock/data";
-import { templates } from "./mock/templates";
-import { guidelines } from "./mock/guidelines";
+import { guidelineSection } from "./mock/guidelines";
+import { templateSection } from "./mock/templates";
 import { LinkChooserProps, SearchResult } from "./types";
 import { doesContainSubstring } from "./utils/helpers";
 
@@ -33,23 +33,34 @@ export default {
 const getGlobalByQueryMock = (query: string): Promise<SearchResult[]> =>
     new Promise((resolve) =>
         setTimeout(() => {
-            resolve(data.filter((item) => doesContainSubstring(item.title, query)));
+            resolve(data.filter((item) => doesContainSubstring(item.title, query, extraSections)));
         }, Math.floor(Math.random() * 2000)),
     );
 
 const getTemplatesByQueryMock = (query: string): Promise<SearchResult[]> =>
     new Promise((resolve) =>
         setTimeout(() => {
-            resolve(templates.filter((template) => doesContainSubstring(template.title, query)));
+            resolve(
+                templateSection.items?.filter((item) => doesContainSubstring(item.title, query, [templateSection])) ||
+                    [],
+            );
         }, Math.floor(Math.random() * 2000)),
     );
 
 const getGuidelinesByQueryMock = (query: string): Promise<SearchResult[]> =>
     new Promise((resolve) =>
         setTimeout(() => {
-            resolve(guidelines.filter((guideline) => doesContainSubstring(guideline.title, query)));
+            resolve(
+                guidelineSection.items?.filter((item) => doesContainSubstring(item.title, query, [guidelineSection])) ||
+                    [],
+            );
         }, Math.floor(Math.random() * 2000)),
     );
+
+const extraSections = [
+    { ...guidelineSection, getResults: getGuidelinesByQueryMock },
+    { ...templateSection, getResults: getTemplatesByQueryMock },
+];
 
 export const LinkChooser: Story<LinkChooserProps> = (args: LinkChooserProps) => {
     const [openInNewTab, setOpenInNewTab] = useState<boolean>(false);
@@ -58,8 +69,7 @@ export const LinkChooser: Story<LinkChooserProps> = (args: LinkChooserProps) => 
         <LinkChooserComponent
             {...args}
             getGlobalByQuery={getGlobalByQueryMock}
-            getTemplatesByQuery={getTemplatesByQueryMock}
-            getGuidelinesByQuery={getGuidelinesByQueryMock}
+            extraSections={extraSections}
             openInNewTab={openInNewTab}
             label="URL"
             onOpenInNewTabChange={setOpenInNewTab}

--- a/src/components/LinkChooser/LinkChooser.stories.tsx
+++ b/src/components/LinkChooser/LinkChooser.stories.tsx
@@ -5,8 +5,7 @@ import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
 import { LinkChooser as LinkChooserComponent } from "./LinkChooser";
 import { data } from "./mock/data";
-import { guidelineSection } from "./mock/guidelines";
-import { templateSection } from "./mock/templates";
+import { extraSections } from "./sections";
 import { LinkChooserProps, SearchResult } from "./types";
 import { doesContainSubstring } from "./utils/helpers";
 
@@ -36,31 +35,6 @@ const getGlobalByQueryMock = (query: string): Promise<SearchResult[]> =>
             resolve(data.filter((item) => doesContainSubstring(item.title, query, extraSections)));
         }, Math.floor(Math.random() * 2000)),
     );
-
-const getTemplatesByQueryMock = (query: string): Promise<SearchResult[]> =>
-    new Promise((resolve) =>
-        setTimeout(() => {
-            resolve(
-                templateSection.items?.filter((item) => doesContainSubstring(item.title, query, [templateSection])) ||
-                    [],
-            );
-        }, Math.floor(Math.random() * 2000)),
-    );
-
-const getGuidelinesByQueryMock = (query: string): Promise<SearchResult[]> =>
-    new Promise((resolve) =>
-        setTimeout(() => {
-            resolve(
-                guidelineSection.items?.filter((item) => doesContainSubstring(item.title, query, [guidelineSection])) ||
-                    [],
-            );
-        }, Math.floor(Math.random() * 2000)),
-    );
-
-const extraSections = [
-    { ...guidelineSection, getResults: getGuidelinesByQueryMock },
-    { ...templateSection, getResults: getTemplatesByQueryMock },
-];
 
 export const LinkChooser: Story<LinkChooserProps> = (args: LinkChooserProps) => {
     const [openInNewTab, setOpenInNewTab] = useState<boolean>(false);

--- a/src/components/LinkChooser/LinkChooser.tsx
+++ b/src/components/LinkChooser/LinkChooser.tsx
@@ -96,14 +96,14 @@ export const LinkChooser: FC<LinkChooserProps> = ({
     const handleSelectionChange = (key: Key) => {
         const foundItem = context.searchResults.find((item) => item.id === key);
         if (foundItem) {
-            send("SET_SELECTED_SEARCH_RESULT", { data: { selectedResult: foundItem } });
+            send({ type: "SET_SELECTED_SEARCH_RESULT", data: { selectedResult: foundItem } });
         }
         closeBoxState(state);
         setSelectedKey(key);
     };
     const handleInputChange = useCallback(
         (query: string) => {
-            send("TYPING", { data: { query } });
+            send({ type: "TYPING", data: { query } });
         },
         [value],
     );
@@ -136,7 +136,7 @@ export const LinkChooser: FC<LinkChooserProps> = ({
     const handleClearClick = useCallback(() => {
         state.setInputValue("");
         setSelectedKey("");
-        send("CLEARING", { data: { query: "" } });
+        send({ type: "CLEARING", data: { query: "" } });
     }, []);
 
     const handleDropdownOpen = () => {
@@ -166,7 +166,7 @@ export const LinkChooser: FC<LinkChooserProps> = ({
                 selectedResult = createCustomLink(state.inputValue);
             }
         }
-        send("CLOSE_DROPDOWN", { data: { selectedResult } });
+        send({ type: "CLOSE_DROPDOWN", data: { selectedResult } });
         if (selectedResult && selectedKey !== selectedResult.id) {
             setSelectedKey(selectedResult.id);
         }

--- a/src/components/LinkChooser/LinkChooser.tsx
+++ b/src/components/LinkChooser/LinkChooser.tsx
@@ -178,14 +178,15 @@ export const LinkChooser: FC<LinkChooserProps> = ({
         {
             onOpen: handleDropdownOpen,
             onClose: handleDropdownClose,
-            onNavigate: (id) =>
+            onNavigate: (id) => {
                 send({
                     type: "SELECT_EXTRA_SECTION",
                     data: {
                         getExtraResultsByQuery: findSection(extraSections, id)?.getResults || null,
                         currentSectionId: id.toString(),
                     },
-                }),
+                });
+            },
             onSelect: handleSelectionChange,
         },
     );

--- a/src/components/LinkChooser/LinkChooser.tsx
+++ b/src/components/LinkChooser/LinkChooser.tsx
@@ -16,7 +16,7 @@ import { useComboBoxState } from "@react-stately/combobox";
 import { useMachine } from "@xstate/react";
 import { AnimatePresence, motion } from "framer-motion";
 import React, { FC, Key, MouseEvent, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { NavigationMenu, NavigationMenuItem } from "./NavigationMenu";
+import { NavigationMenu } from "./NavigationMenu";
 import { Popover } from "./Popover";
 import { SearchInput } from "./SearchInput";
 import { SearchResultsList } from "./SearchResultsList";
@@ -181,7 +181,10 @@ export const LinkChooser: FC<LinkChooserProps> = ({
             onNavigate: (id) =>
                 send({
                     type: "SELECT_EXTRA_SECTION",
-                    data: { getExtraResultsByQuery: findSection(extraSections, id)?.getResults || null },
+                    data: {
+                        getExtraResultsByQuery: findSection(extraSections, id)?.getResults || null,
+                        currentSectionId: id.toString(),
+                    },
                 }),
             onSelect: handleSelectionChange,
         },
@@ -265,16 +268,6 @@ export const LinkChooser: FC<LinkChooserProps> = ({
                             onClose={handleDropdownClose}
                             maxHeight={maxHeight}
                         >
-                            {shouldGoBack(matches) && (
-                                <div className="tw-mt-2">
-                                    <NavigationMenuItem
-                                        state={state}
-                                        section={defaultSection}
-                                        onPress={() => send("BACK_TO_DEFAULT")}
-                                        direction="left"
-                                    />
-                                </div>
-                            )}
                             <SearchResultsList
                                 {...listBoxProps}
                                 listBoxRef={listBoxRef}

--- a/src/components/LinkChooser/NavigationMenu.tsx
+++ b/src/components/LinkChooser/NavigationMenu.tsx
@@ -27,7 +27,7 @@ export const NavigationMenu: FC<NavigationMenuProps> = ({ machineService, state 
                     onPress={() => {
                         send({
                             type: "SELECT_EXTRA_SECTION",
-                            data: { getExtraResultsByQuery: section.getResults },
+                            data: { getExtraResultsByQuery: section.getResults, currentSectionId: section.id },
                         });
                     }}
                 />

--- a/src/components/LinkChooser/NavigationMenu.tsx
+++ b/src/components/LinkChooser/NavigationMenu.tsx
@@ -52,7 +52,6 @@ export const NavigationMenuItem: FC<NavigationMenuItemProps> = ({
         ref,
     );
 
-    //TODO: access title via context.currentSectionId
     const itemTitle = useMemo(
         () => (id === defaultSection.id ? <p className="tw-ml-1 tw-text-black-80 tw-capitalize">{title}</p> : title),
         [title],

--- a/src/components/LinkChooser/SearchResultOption.tsx
+++ b/src/components/LinkChooser/SearchResultOption.tsx
@@ -1,0 +1,69 @@
+import { MenuItemContentSize } from "@components/MenuItem";
+import { MenuItem } from "@components/MenuItem/MenuItem";
+import { getInteractionModality } from "@react-aria/interactions";
+import { useOption } from "@react-aria/listbox";
+import { merge } from "@utilities/merge";
+import { useActor } from "@xstate/react";
+import React, { FC, useRef } from "react";
+import { IconOptions } from "./LinkChooser";
+import { DropdownState, LinkChooserState, SectionState } from "./state/machine";
+import { ImageMenuItemProps, SearchResultOptionProps } from "./types";
+import { findSection } from "./utils/helpers";
+
+export const SearchResultOption: FC<SearchResultOptionProps> = ({ item, state, keyItemRecord, machineService }) => {
+    const ref = useRef<HTMLLIElement>(null);
+    const { optionProps, isDisabled, isSelected, isFocused } = useOption(
+        {
+            key: item.key,
+            shouldFocusOnHover: false,
+        },
+        state,
+        ref,
+    );
+    const [
+        {
+            context: { extraSections, currentSectionId },
+            matches,
+        },
+    ] = useActor(machineService);
+
+    const menuItem = keyItemRecord[item.key];
+    const decorator = menuItem.icon ? IconOptions[menuItem.icon] : undefined;
+    const currentSection = findSection(extraSections, currentSectionId);
+    const isLoaded = (currentState: DropdownState) =>
+        matches(`${LinkChooserState.Focused}.${currentState}.${SectionState.Loaded}`);
+
+    const isFocusVisible = getInteractionModality() !== "pointer";
+
+    return (
+        <li
+            {...optionProps}
+            ref={ref}
+            className={merge([
+                "tw-relative hover:tw-bg-black-0 tw-list-none tw-outline-none",
+                isDisabled && "tw-pointer-events-none tw-top-px",
+                isFocused && isFocusVisible && "tw-bg-black-0",
+            ])}
+        >
+            {isLoaded(DropdownState.Default) ? (
+                <MenuItem {...menuItem} active={isSelected} decorator={decorator} size={MenuItemContentSize.Large} />
+            ) : isLoaded(DropdownState.ExtraSection) && currentSection?.renderPreview ? (
+                currentSection.renderPreview(menuItem)
+            ) : (
+                <ImageMenuItem {...menuItem} />
+            )}
+        </li>
+    );
+};
+
+const ImageMenuItem: FC<ImageMenuItemProps> = ({ title, subtitle, preview }) => (
+    <div className="tw-flex tw-px-5 tw-py-1.5 tw-cursor-pointer">
+        <div className="tw-flex tw-flex-shrink-0 tw-w-[75px] tw-h-[75px] tw-max-w-xs tw-bg-black-0 tw-rounded">
+            {preview && <img className="tw-w-full tw-object-contain" src={preview} alt={title as string} />}
+        </div>
+        <div className="tw-flex tw-flex-col tw-justify-center tw-ml-4">
+            <p className="tw-block tw-text-md tw-leading-tight tw-hover:underline tw-text-black-80">{title}</p>
+            {subtitle && <p className="tw-text-[12px] tw-text-black-80">{subtitle}</p>}
+        </div>
+    </div>
+);

--- a/src/components/LinkChooser/SearchResultSection.tsx
+++ b/src/components/LinkChooser/SearchResultSection.tsx
@@ -1,0 +1,36 @@
+import { useListBoxSection } from "@react-aria/listbox";
+import React, { FC } from "react";
+import { SearchResultSectionProps } from ".";
+import { SearchResultOption } from "./SearchResultOption";
+
+export const SearchResultSection: FC<SearchResultSectionProps> = ({
+    heading,
+    state,
+    keyItemRecord,
+    machineService,
+}) => {
+    const { itemProps, groupProps } = useListBoxSection({
+        heading: heading.rendered,
+        "aria-label": heading["aria-label"],
+    });
+
+    return (
+        <li {...itemProps} className="tw-border-b tw-border-b-black-10 last:tw-border-0">
+            <ul
+                {...groupProps}
+                data-test-id="link-chooser-select-section"
+                className="tw-py-2 tw-px-0 tw-m-0 tw-list-none"
+            >
+                {[...heading.childNodes].map((node) => (
+                    <SearchResultOption
+                        key={node.key}
+                        item={node}
+                        state={state}
+                        keyItemRecord={keyItemRecord}
+                        machineService={machineService}
+                    />
+                ))}
+            </ul>
+        </li>
+    );
+};

--- a/src/components/LinkChooser/SearchResultsList.tsx
+++ b/src/components/LinkChooser/SearchResultsList.tsx
@@ -48,12 +48,12 @@ export const SearchResultsList: FC<SearchResultListProps> = (props) => {
                     <NavigationMenuItem
                         state={state}
                         section={currentSection}
-                        onPress={() =>
+                        onPress={() => {
                             send({
                                 type: "BACK_TO_DEFAULT",
                                 data: { getExtraResultsByQuery: null },
-                            })
-                        }
+                            });
+                        }}
                         direction="left"
                     />
                 </div>

--- a/src/components/LinkChooser/SearchResultsList.tsx
+++ b/src/components/LinkChooser/SearchResultsList.tsx
@@ -1,21 +1,16 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { getKeyItemRecord, getMenuItems } from "@components/ActionMenu/Aria/helper";
-import { MenuItemContentSize } from "@components/MenuItem";
-import { MenuItem } from "@components/MenuItem/MenuItem";
-import { getInteractionModality } from "@react-aria/interactions";
-import { useListBox, useListBoxSection, useOption } from "@react-aria/listbox";
-import { merge } from "@utilities/merge";
+import { useListBox } from "@react-aria/listbox";
 import { useActor } from "@xstate/react";
 import React, { FC, useMemo, useRef } from "react";
 import BackgroundIcon from "./assets/background.svg";
 import NoResultsIcon from "./assets/no-results.svg";
 import FetchingIcon from "./assets/nook-animated.png";
-import { IconOptions } from "./LinkChooser";
 import { NavigationMenuItem } from "./NavigationMenu";
+import { SearchResultSection } from "./SearchResultSection";
 import { defaultSection } from "./sections";
-import { DropdownState, LinkChooserState, SectionState } from "./state/machine";
-import { ImageMenuItemProps, SearchResultListProps, SearchResultOptionProps, SearchResultSectionProps } from "./types";
+import { SearchResultListProps } from "./types";
 import { findSection } from "./utils/helpers";
 import { isFetching, isUnsuccessful, shouldGoBack } from "./utils/state";
 
@@ -26,11 +21,17 @@ export const SearchResultsList: FC<SearchResultListProps> = (props) => {
     const items = getMenuItems(menuBlocks);
     const keyItemRecord = getKeyItemRecord(items);
 
-    const [{ context, matches }, send] = useActor(machineService);
+    const [
+        {
+            context: { extraSections, currentSectionId, searchResults, query },
+            matches,
+        },
+        send,
+    ] = useActor(machineService);
 
     const currentSection = useMemo(
-        () => findSection(context.extraSections, context.currentSectionId) || defaultSection,
-        [context.currentSectionId],
+        () => findSection(extraSections, currentSectionId) || defaultSection,
+        [currentSectionId],
     );
 
     if (isFetching(matches)) {
@@ -64,7 +65,7 @@ export const SearchResultsList: FC<SearchResultListProps> = (props) => {
                 ref={listBoxRef}
                 className="tw-list-none tw-p-0 tw-m-0 tw-bg-white tw-z-20 focus-visible:tw-outline-none"
             >
-                {context.searchResults.length ? (
+                {searchResults.length ? (
                     [...state.collection]
                         .filter((section) => section.key === "search")
                         .map((item) => (
@@ -79,83 +80,15 @@ export const SearchResultsList: FC<SearchResultListProps> = (props) => {
                 ) : (
                     <EmptyResults
                         prompt={
-                            context.query
-                                ? `We could not find any results for "${context.query}".`
+                            query
+                                ? `We could not find any results for "${query}".`
                                 : "Use the search above to discover your brand assets"
                         }
-                        icon={context.query ? NoResultsIcon : BackgroundIcon}
+                        icon={query ? NoResultsIcon : BackgroundIcon}
                     />
                 )}
             </ul>
         </div>
-    );
-};
-
-const SearchResultSection: FC<SearchResultSectionProps> = ({ heading, state, keyItemRecord, machineService }) => {
-    const { itemProps, groupProps } = useListBoxSection({
-        heading: heading.rendered,
-        "aria-label": heading["aria-label"],
-    });
-
-    return (
-        <li {...itemProps} className="tw-border-b tw-border-b-black-10 last:tw-border-0">
-            <ul
-                {...groupProps}
-                data-test-id="link-chooser-select-section"
-                className="tw-py-2 tw-px-0 tw-m-0 tw-list-none"
-            >
-                {[...heading.childNodes].map((node) => (
-                    <SearchResultOption
-                        key={node.key}
-                        item={node}
-                        state={state}
-                        keyItemRecord={keyItemRecord}
-                        machineService={machineService}
-                    />
-                ))}
-            </ul>
-        </li>
-    );
-};
-
-const SearchResultOption: FC<SearchResultOptionProps> = ({ item, state, keyItemRecord, machineService }) => {
-    const ref = useRef<HTMLLIElement>(null);
-    const { optionProps, isDisabled, isSelected, isFocused } = useOption(
-        {
-            key: item.key,
-            shouldFocusOnHover: false,
-        },
-        state,
-        ref,
-    );
-    const [{ context, matches }] = useActor(machineService);
-
-    const menuItem = keyItemRecord[item.key];
-    const decorator = menuItem.icon ? IconOptions[menuItem.icon] : undefined;
-    const currentSection = findSection(context.extraSections, context.currentSectionId);
-    const isLoaded = (currentState: DropdownState) =>
-        matches(`${LinkChooserState.Focused}.${currentState}.${SectionState.Loaded}`);
-
-    const isFocusVisible = getInteractionModality() !== "pointer";
-
-    return (
-        <li
-            {...optionProps}
-            ref={ref}
-            className={merge([
-                "tw-relative hover:tw-bg-black-0 tw-list-none tw-outline-none",
-                isDisabled && "tw-pointer-events-none tw-top-px",
-                isFocused && isFocusVisible && "tw-bg-black-0",
-            ])}
-        >
-            {isLoaded(DropdownState.Default) ? (
-                <MenuItem {...menuItem} active={isSelected} decorator={decorator} size={MenuItemContentSize.Large} />
-            ) : isLoaded(DropdownState.ExtraSection) && currentSection?.renderPreview ? (
-                currentSection.renderPreview(menuItem)
-            ) : (
-                <ImageMenuItem {...menuItem} />
-            )}
-        </li>
     );
 };
 
@@ -185,17 +118,5 @@ const FetchingAnimation: FC = () => (
         className="tw-flex tw-flex-col tw-justify-center tw-items-center tw-h-[220px] tw-p-3"
     >
         <img className="tw-w-[50px]" src={FetchingIcon} alt="Fetching" />
-    </div>
-);
-
-const ImageMenuItem: FC<ImageMenuItemProps> = ({ title, subtitle, preview }) => (
-    <div className="tw-flex tw-px-5 tw-py-1.5 tw-cursor-pointer">
-        <div className="tw-flex tw-shrink-0 tw-w-[75px] tw-h-[75px] tw-max-w-xs tw-bg-black-0 tw-rounded">
-            {preview && <img className="tw-w-full tw-object-contain" src={preview} alt={title as string} />}
-        </div>
-        <div className="tw-flex tw-flex-col tw-justify-center tw-ml-4">
-            <p className="tw-block tw-text-md tw-leading-tight tw-hover:underline tw-text-black-80">{title}</p>
-            {subtitle && <p className="tw-text-[12px] tw-text-black-80">{subtitle}</p>}
-        </div>
     </div>
 );

--- a/src/components/LinkChooser/mock/data.ts
+++ b/src/components/LinkChooser/mock/data.ts
@@ -1,11 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { IconLabel, ImageSearchResult, SearchResult } from "../types";
-import { guidelines } from "./guidelines";
-import { templates } from "./templates";
+import { guidelineSection } from "./guidelines";
+import { templateSection } from "./templates";
 
-const formatImageItemData = (array: ImageSearchResult[]): SearchResult[] =>
-    array.map(({ id, title, subtitle, link, icon }) => ({ id, title, subtitle, link, icon }));
+const formatImageItemData = (array: (ImageSearchResult | SearchResult)[]): SearchResult[] =>
+    array.map(({ id, title, subtitle, link, icon }) => ({ id, title, subtitle, link, icon })) || [];
 
 export const data = [
     {
@@ -35,6 +35,6 @@ export const data = [
         link: "https://www.frontify.com/en/digital-and-print-templates/",
         icon: IconLabel.External,
     },
-    ...formatImageItemData(templates),
-    ...formatImageItemData(guidelines),
+    ...formatImageItemData(templateSection.items),
+    ...formatImageItemData(guidelineSection.items),
 ];

--- a/src/components/LinkChooser/mock/guidelines.ts
+++ b/src/components/LinkChooser/mock/guidelines.ts
@@ -1,51 +1,56 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { ExtraSection } from "..";
 import { IconLabel } from "../types";
 
-export const guidelines = [
-    {
-        id: "15",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC84MVwvNzA2MzRcL2RmZGNiYjg0NDc2Zjg1NWZkN2NkYTZmZjVhZGQ0OWY3LTE1OTc4NDY1MDQuanBnIn0:demo:pbBQjnMpyPm-Y3VIT3PsjRvxAcgjf_Fu66NBGxhGzm4",
-        title: "Brand Guideline 1",
-        subtitle: "Corporate Library",
-        link: "#",
-        icon: IconLabel.Document,
-    },
-    {
-        id: "16",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9hMlwvMTc2ODg1XC83ODVhNDE2MGU3MmI4MmIwMjI2MWYyZmI5ZjM4MzQ3Zi0xNTg4MTcxNDU3LmpwZyJ9:demo:BdZSW_EJ9MK7tj97PJWAYoI-JQpLSCoNuem8yPsJRRU",
-        title: "Brooklyn",
-        subtitle: "Brand Guideline 2",
-        link: "#",
-        icon: IconLabel.Document,
-    },
-    {
-        id: "17",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC8xNlwvMTg5MDQ0XC81YTBlMmY3NDNlYzg5NmMwNWUyYmYzOTQ3ZjIzZjNiZS0xNTkxMzUwNDgyLmpwZyJ9:demo:N71e31eSauAlSP3ftzqghrfXBrfKg4j-5Fz6oepIN2w",
-        title: "Internal Project: SRF Kultur",
-        subtitle: "",
-        link: "#",
-        icon: IconLabel.Library,
-    },
-    {
-        id: "18",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9mMVwvNzA2MDlcL2E2ZjZiOTRjYTZlYWY2NDM5YzJkM2UxODA1MjllNzc1LTE1NTE2ODc1ODUuanBnIn0:demo:y-gQs4zFi04GXZs0muCnngE6IHJsHSbDuUDdVAjuXPI",
-        title: "Color Block",
-        subtitle: "UNICEF Social Campaign",
-        link: "#",
-        icon: IconLabel.Document,
-    },
-    {
-        id: "19",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC85MFwvMTcxOTA4XC8yZWYyZTcyZjc0NmMxNGYwZWRiYzU2ZTg5NWU0OGFkMC0xNTg2MjQ2MDE4LmpwZyJ9:demo:OzFxNwODI9hPk1xTxCQBPRA3GNKhvMWM5x6d5ZeCRN4",
-        title: "Brand Business View",
-        subtitle: "Guideline Library",
-        link: "#",
-        icon: IconLabel.Template,
-    },
-];
+export const guidelineSection: ExtraSection = {
+    id: "guidelines",
+    title: "Guidelines",
+    items: [
+        {
+            id: "15",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC84MVwvNzA2MzRcL2RmZGNiYjg0NDc2Zjg1NWZkN2NkYTZmZjVhZGQ0OWY3LTE1OTc4NDY1MDQuanBnIn0:demo:pbBQjnMpyPm-Y3VIT3PsjRvxAcgjf_Fu66NBGxhGzm4",
+            title: "Brand Guideline 1",
+            subtitle: "Corporate Library",
+            link: "#",
+            icon: IconLabel.Document,
+        },
+        {
+            id: "16",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9hMlwvMTc2ODg1XC83ODVhNDE2MGU3MmI4MmIwMjI2MWYyZmI5ZjM4MzQ3Zi0xNTg4MTcxNDU3LmpwZyJ9:demo:BdZSW_EJ9MK7tj97PJWAYoI-JQpLSCoNuem8yPsJRRU",
+            title: "Brooklyn",
+            subtitle: "Brand Guideline 2",
+            link: "#",
+            icon: IconLabel.Document,
+        },
+        {
+            id: "17",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC8xNlwvMTg5MDQ0XC81YTBlMmY3NDNlYzg5NmMwNWUyYmYzOTQ3ZjIzZjNiZS0xNTkxMzUwNDgyLmpwZyJ9:demo:N71e31eSauAlSP3ftzqghrfXBrfKg4j-5Fz6oepIN2w",
+            title: "Internal Project: SRF Kultur",
+            subtitle: "",
+            link: "#",
+            icon: IconLabel.Library,
+        },
+        {
+            id: "18",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9mMVwvNzA2MDlcL2E2ZjZiOTRjYTZlYWY2NDM5YzJkM2UxODA1MjllNzc1LTE1NTE2ODc1ODUuanBnIn0:demo:y-gQs4zFi04GXZs0muCnngE6IHJsHSbDuUDdVAjuXPI",
+            title: "Color Block",
+            subtitle: "UNICEF Social Campaign",
+            link: "#",
+            icon: IconLabel.Document,
+        },
+        {
+            id: "19",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC85MFwvMTcxOTA4XC8yZWYyZTcyZjc0NmMxNGYwZWRiYzU2ZTg5NWU0OGFkMC0xNTg2MjQ2MDE4LmpwZyJ9:demo:OzFxNwODI9hPk1xTxCQBPRA3GNKhvMWM5x6d5ZeCRN4",
+            title: "Brand Business View",
+            subtitle: "Guideline Library",
+            link: "#",
+            icon: IconLabel.Template,
+        },
+    ],
+};

--- a/src/components/LinkChooser/mock/guidelines.ts
+++ b/src/components/LinkChooser/mock/guidelines.ts
@@ -1,11 +1,20 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ExtraSection } from "..";
+import { ExtraSection, SearchResult } from "..";
 import { IconLabel } from "../types";
+import { filterItems } from "../utils/helpers";
+
+const getGuidelinesByQueryMock = (query: string): Promise<SearchResult[]> =>
+    new Promise((resolve) =>
+        setTimeout(() => {
+            resolve(filterItems(query, guidelineSection.items, [guidelineSection]) || []);
+        }, Math.floor(Math.random() * 2000)),
+    );
 
 export const guidelineSection: ExtraSection = {
     id: "guidelines",
     title: "Guidelines",
+    getResults: getGuidelinesByQueryMock,
     items: [
         {
             id: "15",

--- a/src/components/LinkChooser/mock/templates.ts
+++ b/src/components/LinkChooser/mock/templates.ts
@@ -1,13 +1,22 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ExtraSection } from "..";
+import { ExtraSection, SearchResult } from "..";
 import { IconLabel } from "../types";
+import { filterItems } from "../utils/helpers";
 
 const defaultTemplateProps = { link: "#", icon: IconLabel.Template };
+
+const getTemplatesByQueryMock = (query: string): Promise<SearchResult[]> =>
+    new Promise((resolve) =>
+        setTimeout(() => {
+            resolve(filterItems(query, templateSection.items, [templateSection]) || []);
+        }, Math.floor(Math.random() * 2000)),
+    );
 
 export const templateSection: ExtraSection = {
     id: "templates",
     title: "Templates",
+    getResults: getTemplatesByQueryMock,
     items: [
         {
             id: "7",

--- a/src/components/LinkChooser/mock/templates.ts
+++ b/src/components/LinkChooser/mock/templates.ts
@@ -1,48 +1,53 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { ExtraSection } from "..";
 import { IconLabel } from "../types";
 
 const defaultTemplateProps = { link: "#", icon: IconLabel.Template };
 
-export const templates = [
-    {
-        id: "7",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9hY1wvMTcyMDM0XC8yYzA5YTI1YjRmZDU1NTY4MDkzNjM3YzAwZDEyNWUzZC0xNTg2MjQ3Nzc5LmpwZyJ9:demo:lwxQ6B1hNWa7dUuxdWBh3x6tad8uuVooSriyYfSdVX8",
-        title: "Aerial City View",
-        subtitle: "Corporate Library",
-        ...defaultTemplateProps,
-    },
-    {
-        id: "8",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9jNVwvMTc2ODg4XC83MWNjYjQ1M2FhNjViZTcwZDQ1ZGJhOGMzOTg4NDcwNC0xNTg4MTcxNDU3LmpwZyJ9:demo:EJ7NNdX5vL6j9bQ_QT4fsB7FPHsyGnHM0DD4YzpXj90",
-        title: "Brooklyn",
-        subtitle: "Template Library Old Brand",
-        ...defaultTemplateProps,
-    },
-    {
-        id: "9",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9lZlwvMTg1OTIxXC9mOTU2NWVjMzZkNWQyZDQ2MDYwYjBhNzAxMjA1NDA1YS0xNTkwMDUzMTU3LmpwZyJ9:demo:0W8ccsKqSqEeknGWZAwTMngnEZfMYbIojonwqXnoU14",
-        title: "City",
-        subtitle: "SRF Kultur On Screen",
-        ...defaultTemplateProps,
-    },
-    {
-        id: "10",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC80NVwvMTcyMjk3XC84NWZkOWViYzkyYTQ1MTI4MGVkMTdmMGE2NDI0ZTMyMC0xNTg2MjcwNDY3LmpwZyJ9:demo:gR7jAgdZiD97tGOBl7fyACffrjq5IplWVZWmDNDa_JE",
-        title: "Malaya Poster",
-        subtitle: "UNICEF Social Campaign",
-        ...defaultTemplateProps,
-    },
-    {
-        id: "11",
-        preview:
-            "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC84NVwvMTcyMjk4XC81NTdjMzk5YTRlYTBhM2IxZWZhNGFmYzIzZjU3ODMzNy0xNTg2MjcwNDY3LmpwZyJ9:demo:6UgRwLcJnQosciitSqFaGXpvuoFtlQAUCC3rXT7tmN8",
-        title: "Brand Business Card",
-        subtitle: "Corporate Library",
-        ...defaultTemplateProps,
-    },
-];
+export const templateSection: ExtraSection = {
+    id: "templates",
+    title: "Templates",
+    items: [
+        {
+            id: "7",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9hY1wvMTcyMDM0XC8yYzA5YTI1YjRmZDU1NTY4MDkzNjM3YzAwZDEyNWUzZC0xNTg2MjQ3Nzc5LmpwZyJ9:demo:lwxQ6B1hNWa7dUuxdWBh3x6tad8uuVooSriyYfSdVX8",
+            title: "Aerial City View",
+            subtitle: "Corporate Library",
+            ...defaultTemplateProps,
+        },
+        {
+            id: "8",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9jNVwvMTc2ODg4XC83MWNjYjQ1M2FhNjViZTcwZDQ1ZGJhOGMzOTg4NDcwNC0xNTg4MTcxNDU3LmpwZyJ9:demo:EJ7NNdX5vL6j9bQ_QT4fsB7FPHsyGnHM0DD4YzpXj90",
+            title: "Brooklyn",
+            subtitle: "Template Library Old Brand",
+            ...defaultTemplateProps,
+        },
+        {
+            id: "9",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC9lZlwvMTg1OTIxXC9mOTU2NWVjMzZkNWQyZDQ2MDYwYjBhNzAxMjA1NDA1YS0xNTkwMDUzMTU3LmpwZyJ9:demo:0W8ccsKqSqEeknGWZAwTMngnEZfMYbIojonwqXnoU14",
+            title: "City",
+            subtitle: "SRF Kultur On Screen",
+            ...defaultTemplateProps,
+        },
+        {
+            id: "10",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC80NVwvMTcyMjk3XC84NWZkOWViYzkyYTQ1MTI4MGVkMTdmMGE2NDI0ZTMyMC0xNTg2MjcwNDY3LmpwZyJ9:demo:gR7jAgdZiD97tGOBl7fyACffrjq5IplWVZWmDNDa_JE",
+            title: "Malaya Poster",
+            subtitle: "UNICEF Social Campaign",
+            ...defaultTemplateProps,
+        },
+        {
+            id: "11",
+            preview:
+                "https://cdn-assets-eu.frontify.com/s3/frontify-enterprise-files-eu/eyJwYXRoIjoiZGVtb1wvYWNjb3VudHNcLzBmXC83MDAwMDQ3XC9wcm9qZWN0c1wvMzc5NFwvYXNzZXRzXC84NVwvMTcyMjk4XC81NTdjMzk5YTRlYTBhM2IxZWZhNGFmYzIzZjU3ODMzNy0xNTg2MjcwNDY3LmpwZyJ9:demo:6UgRwLcJnQosciitSqFaGXpvuoFtlQAUCC3rXT7tmN8",
+            title: "Brand Business Card",
+            subtitle: "Corporate Library",
+            ...defaultTemplateProps,
+        },
+    ],
+};

--- a/src/components/LinkChooser/sections.ts
+++ b/src/components/LinkChooser/sections.ts
@@ -1,16 +1,3 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-export const sections = [
-    {
-        id: "guidelines",
-        sectionId: "GUIDELINES",
-        title: "Guidelines",
-    },
-    {
-        id: "templates",
-        sectionId: "TEMPLATES",
-        title: "Templates",
-    },
-];
-
-export const defaultSection = { id: "default", sectionId: "DEFAULT", title: "Default" };
+export const defaultSection = { id: "default", title: "Default", items: [] };

--- a/src/components/LinkChooser/sections.ts
+++ b/src/components/LinkChooser/sections.ts
@@ -1,3 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { guidelineSection } from "./mock/guidelines";
+import { templateSection } from "./mock/templates";
+
 export const defaultSection = { id: "default", title: "Default", items: [] };
+
+export const extraSections = [guidelineSection, templateSection];

--- a/src/components/LinkChooser/state/actions.ts
+++ b/src/components/LinkChooser/state/actions.ts
@@ -3,6 +3,7 @@
 import { QUERIES_STORAGE_KEY } from "@components/LinkChooser/LinkChooser";
 import { assign, DoneInvokeEvent } from "xstate";
 import { SearchResult } from "..";
+import { defaultSection } from "../sections";
 import { LinkChooserContext, LinkChooserEventData } from "../types";
 import { isCustomLink } from "../utils/helpers";
 import { createCustomLink, mergeResultWithRecentQueries, retrieveRecentQueries } from "../utils/transformers";
@@ -60,10 +61,11 @@ export const replaceCustomLinkWithSelected = assign<LinkChooserContext, DoneInvo
 });
 
 export const setExtraResultsByQuery = assign<LinkChooserContext, DoneInvokeEvent<LinkChooserEventData>>({
-    getExtraResultsByQuery: (_, { data }) => {
-        console.log(data);
-        return data?.getExtraResultsByQuery ?? null;
-    },
+    getExtraResultsByQuery: (_, { data }) => data.getExtraResultsByQuery ?? null,
+});
+
+export const setCurrentSectionId = assign<LinkChooserContext, DoneInvokeEvent<LinkChooserEventData>>({
+    currentSectionId: (_, { data }) => data.currentSectionId ?? defaultSection.id,
 });
 
 export const setSelectedSearchResult = assign<LinkChooserContext, DoneInvokeEvent<LinkChooserEventData>>({

--- a/src/components/LinkChooser/state/actions.ts
+++ b/src/components/LinkChooser/state/actions.ts
@@ -2,6 +2,7 @@
 
 import { QUERIES_STORAGE_KEY } from "@components/LinkChooser/LinkChooser";
 import { assign, DoneInvokeEvent } from "xstate";
+import { SearchResult } from "..";
 import { LinkChooserContext, LinkChooserEventData } from "../types";
 import { isCustomLink } from "../utils/helpers";
 import { createCustomLink, mergeResultWithRecentQueries, retrieveRecentQueries } from "../utils/transformers";
@@ -58,6 +59,13 @@ export const replaceCustomLinkWithSelected = assign<LinkChooserContext, DoneInvo
     },
 });
 
+export const setExtraResultsByQuery = assign<LinkChooserContext, DoneInvokeEvent<LinkChooserEventData>>({
+    getExtraResultsByQuery: (_, { data }) => {
+        console.log(data);
+        return data?.getExtraResultsByQuery ?? null;
+    },
+});
+
 export const setSelectedSearchResult = assign<LinkChooserContext, DoneInvokeEvent<LinkChooserEventData>>({
     selectedResult: (_, { data }) => data.selectedResult ?? null,
 });
@@ -110,13 +118,13 @@ export const fetchGlobalSearchResults = async (context: LinkChooserContext): Pro
     return { searchResults: results };
 };
 
-export const fetchTemplateSearchResults = async (context: LinkChooserContext): Promise<LinkChooserEventData> => {
-    const results = await context.getTemplatesByQuery(context.query);
-    return { searchResults: results };
-};
+export const fetchExtraSectionResults = async (context: LinkChooserContext): Promise<LinkChooserEventData> => {
+    let results: SearchResult[] = [];
 
-export const fetchGuidelineSearchResults = async (context: LinkChooserContext): Promise<LinkChooserEventData> => {
-    const results = await context.getGuidelinesByQuery(context.query);
+    if (context.getExtraResultsByQuery !== null) {
+        results = await context.getExtraResultsByQuery(context.query);
+    }
+
     return { searchResults: results };
 };
 

--- a/src/components/LinkChooser/state/machine.ts
+++ b/src/components/LinkChooser/state/machine.ts
@@ -7,21 +7,21 @@ import {
     clearSelectedResult,
     copyLinkToClipboard,
     emitSelectSearchResult,
+    fetchExtraSectionResults,
     fetchGlobalSearchResults,
-    fetchTemplateSearchResults,
+    fillResultsWithNewRecentQueries,
+    interruptFetching,
     openPreviewContext,
     populateDropdownSearchResultsWithRecentQueries,
+    replaceCustomLink,
+    replaceCustomLinkWithSelected,
+    resolveFetching,
+    setExtraResultsByQuery,
     setSelectedSearchResult,
     storeNewSelectedResult,
-    replaceCustomLinkWithSelected,
-    replaceCustomLink,
     updateDropdownSearchResults,
     updateQueryFromObject,
     updateQueryFromString,
-    interruptFetching,
-    resolveFetching,
-    fetchGuidelineSearchResults,
-    fillResultsWithNewRecentQueries,
 } from "./actions";
 
 export enum LinkChooserState {
@@ -31,8 +31,7 @@ export enum LinkChooserState {
 
 export enum DropdownState {
     Default = "default",
-    Guidelines = "guidelines",
-    Templates = "templates",
+    ExtraSection = "extra-section",
 }
 
 export enum SectionState {
@@ -169,28 +168,23 @@ export const linkChooserMachine = createMachine<LinkChooserContext, DoneInvokeEv
                     [DropdownState.Default]: {
                         ...initializeSectionState(SectionState.Loaded, "fetchGlobal", fetchGlobalSearchResults),
                         on: {
-                            GO_TO_GUIDELINES: DropdownState.Guidelines,
-                            GO_TO_TEMPLATES: DropdownState.Templates,
-                        },
-                    },
-                    [DropdownState.Guidelines]: {
-                        ...initializeSectionState(
-                            SectionState.Fetching,
-                            "fetchGuidelines",
-                            fetchGuidelineSearchResults,
-                        ),
-                        on: {
-                            GO_TO_DEFAULT: `${DropdownState.Default}.${SectionState.Fetching}`,
-                            CLEARING: {
-                                target: DropdownState.Default,
-                                actions: [...clearingActions],
+                            SELECT_EXTRA_SECTION: {
+                                target: DropdownState.ExtraSection,
+                                actions: [setExtraResultsByQuery],
                             },
                         },
                     },
-                    [DropdownState.Templates]: {
-                        ...initializeSectionState(SectionState.Fetching, "fetchTemplates", fetchTemplateSearchResults),
+                    [DropdownState.ExtraSection]: {
+                        ...initializeSectionState(
+                            SectionState.Fetching,
+                            "fetchExtraSectionResults",
+                            fetchExtraSectionResults,
+                        ),
                         on: {
-                            GO_TO_DEFAULT: `${DropdownState.Default}.${SectionState.Fetching}`,
+                            BACK_TO_DEFAULT: {
+                                target: `${DropdownState.Default}.${SectionState.Fetching}`,
+                                actions: [setExtraResultsByQuery],
+                            },
                             CLEARING: {
                                 target: DropdownState.Default,
                                 actions: [...clearingActions],
@@ -236,7 +230,7 @@ export const linkChooserMachine = createMachine<LinkChooserContext, DoneInvokeEv
             copyLinkToClipboard,
             emitSelectSearchResult,
             fetchGlobalSearchResults,
-            fetchTemplateSearchResults,
+            setExtraResultsByQuery,
             openPreviewContext,
             populateDropdownSearchResultsWithRecentQueries,
             fillResultsWithNewRecentQueries,

--- a/src/components/LinkChooser/state/machine.ts
+++ b/src/components/LinkChooser/state/machine.ts
@@ -188,7 +188,7 @@ export const linkChooserMachine = createMachine<LinkChooserContext, DoneInvokeEv
                             },
                             CLEARING: {
                                 target: DropdownState.Default,
-                                actions: [...clearingActions],
+                                actions: clearingActions,
                             },
                         },
                     },

--- a/src/components/LinkChooser/state/machine.ts
+++ b/src/components/LinkChooser/state/machine.ts
@@ -16,6 +16,7 @@ import {
     replaceCustomLink,
     replaceCustomLinkWithSelected,
     resolveFetching,
+    setCurrentSectionId,
     setExtraResultsByQuery,
     setSelectedSearchResult,
     storeNewSelectedResult,
@@ -170,7 +171,7 @@ export const linkChooserMachine = createMachine<LinkChooserContext, DoneInvokeEv
                         on: {
                             SELECT_EXTRA_SECTION: {
                                 target: DropdownState.ExtraSection,
-                                actions: [setExtraResultsByQuery],
+                                actions: [setExtraResultsByQuery, setCurrentSectionId],
                             },
                         },
                     },
@@ -183,7 +184,7 @@ export const linkChooserMachine = createMachine<LinkChooserContext, DoneInvokeEv
                         on: {
                             BACK_TO_DEFAULT: {
                                 target: `${DropdownState.Default}.${SectionState.Fetching}`,
-                                actions: [setExtraResultsByQuery],
+                                actions: [setExtraResultsByQuery, setCurrentSectionId],
                             },
                             CLEARING: {
                                 target: DropdownState.Default,
@@ -231,6 +232,7 @@ export const linkChooserMachine = createMachine<LinkChooserContext, DoneInvokeEv
             emitSelectSearchResult,
             fetchGlobalSearchResults,
             setExtraResultsByQuery,
+            setCurrentSectionId,
             openPreviewContext,
             populateDropdownSearchResultsWithRecentQueries,
             fillResultsWithNewRecentQueries,

--- a/src/components/LinkChooser/utils/helpers.ts
+++ b/src/components/LinkChooser/utils/helpers.ts
@@ -27,3 +27,6 @@ export const findSection = (sections: ExtraSection[], id: Key) => sections.find(
 
 export const isCustomLink = (link: SearchResult | null) =>
     !link || (typeof link.id === "string" && link.id.includes(CUSTOM_LINK_ID));
+
+export const filterItems = (query: string, results: SearchResult[], section: ExtraSection[] = []): SearchResult[] =>
+    results.filter((item) => doesContainSubstring(item.title, query, section));

--- a/src/components/LinkChooser/utils/helpers.ts
+++ b/src/components/LinkChooser/utils/helpers.ts
@@ -1,15 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Key } from "react";
+import { ExtraSection } from "..";
 import { CUSTOM_LINK_ID, DEFAULT_ICON, IconOptions } from "../LinkChooser";
-import { defaultSection, sections } from "../sections";
+import { defaultSection } from "../sections";
 import { SearchResult } from "../types";
 
-export const doesContainSubstring = (source: string, target: string): boolean =>
+export const doesContainSubstring = (source: string, target: string, sections: ExtraSection[]): boolean =>
     source.toLowerCase().includes(target.toLowerCase()) ||
-    [...sections, defaultSection].some((section) => {
-        return section.title.toLowerCase() === source.toLowerCase();
-    });
+    [...sections, defaultSection].some((section) => section.title.toLowerCase() === source.toLowerCase());
 
 export const getDefaultData = async (): Promise<SearchResult[]> =>
     new Promise((resolve) =>
@@ -24,10 +23,7 @@ export const decoratedResults = (results: SearchResult[]) =>
         decorator: IconOptions[item.icon || DEFAULT_ICON],
     }));
 
-export const goToSection = (id: Key, send: (data: string) => void) => {
-    const selectedSection = sections.find((section) => id === section.id) || defaultSection;
-    send(`GO_TO_${selectedSection?.sectionId}`);
-};
+export const findSection = (sections: ExtraSection[], id: Key) => sections.find((section) => section.id === id);
 
 export const isCustomLink = (link: SearchResult | null) =>
     !link || (typeof link.id === "string" && link.id.includes(CUSTOM_LINK_ID));

--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -92,11 +92,11 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
     }, [clear]);
 
     useEffect(() => {
-        send("SET_LOCKED", { data: { locked: readonly } });
+        send({ type: "SET_LOCKED", data: { locked: readonly } });
     }, [readonly]);
 
     useEffect(() => {
-        send("TEXT_UPDATED", { data: { value } });
+        send({ type: "TEXT_UPDATED", data: { value } });
     }, [debouncedValue]);
 
     const onValueChanged = useCallback(
@@ -108,7 +108,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
     );
 
     const onTextSelected = useCallback(
-        debounce(() => send("TEXT_SELECTED", { data: { editor } }), TOOLBAR_DELAY_IN_MS),
+        debounce(() => send({ type: "TEXT_SELECTED", data: { editor } }), TOOLBAR_DELAY_IN_MS),
         [editor],
     );
 
@@ -134,7 +134,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
                     onKeyPress={softBreakHandler}
                     renderLeaf={renderInlineStyles}
                     renderElement={renderBlockStyles}
-                    onBlur={() => send("BLUR", { data: { value } })}
+                    onBlur={() => send({ type: "BLUR", data: { value } })}
                 />
                 {matches(States.Styling) && (
                     <ToolbarContext.Provider


### PR DESCRIPTION
Concerns this ticket: https://app.clickup.com/t/23yxnvc

This PR removes some of the Business Logic from the LinkChooser by replacing it with a more flexibel approach to add custom `extraSections`.

Keyboard navigation is only partly working and will be addressed in this follow-up ticket: https://app.clickup.com/t/24g28a0