### PR TITLE
feat: add hoverable state to card component

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -10,6 +10,9 @@ import { Divider } from "@components/Divider/Divider";
 export default {
     title: "Components/Card",
     component: Card,
+    args: {
+        isHoverable: false,
+    },
 } as Meta<CardProps>;
 
 type Texts = {
@@ -43,6 +46,7 @@ export const Default = Template.bind({});
 
 Default.args = {
     children: "Children",
+    isHoverable: false,
 };
 
 const ChildComponent = () => {
@@ -73,6 +77,7 @@ export const WithSeparator = Template.bind({});
 
 WithSeparator.args = {
     children: <ChildComponent />,
+    isHoverable: false,
 };
 
 const childItems = data.map((item) => ({

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -46,7 +46,6 @@ export const Default = Template.bind({});
 
 Default.args = {
     children: "Children",
-    isHoverable: false,
 };
 
 const ChildComponent = () => {
@@ -77,7 +76,6 @@ export const WithSeparator = Template.bind({});
 
 WithSeparator.args = {
     children: <ChildComponent />,
-    isHoverable: false,
 };
 
 const childItems = data.map((item) => ({

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -11,7 +11,7 @@ export default {
     title: "Components/Card",
     component: Card,
     args: {
-        isHoverable: false,
+        hoverable: false,
     },
 } as Meta<CardProps>;
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -4,17 +4,17 @@ import { merge } from "@utilities/merge";
 import React, { FC, ReactChild } from "react";
 
 export type CardProps = {
-    isHoverable?: boolean;
+    hoverable?: boolean;
     children?: ReactChild;
 };
 
-export const Card: FC<CardProps> = ({ isHoverable = false, children }) => {
+export const Card: FC<CardProps> = ({ hoverable = false, children }) => {
     return (
         <div
             data-test-id="card"
             className={merge([
                 "tw-w-full tw-bg-white tw-border tw-border-black-10 tw-rounded",
-                isHoverable ? "hover:tw-border-black" : "",
+                hoverable ? "hover:tw-border-black" : "",
             ])}
         >
             {children}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,14 +1,22 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { merge } from "@utilities/merge";
 import React, { FC, ReactChild } from "react";
 
 export type CardProps = {
+    isHoverable?: boolean;
     children?: ReactChild;
 };
 
-export const Card: FC<CardProps> = ({ children }) => {
+export const Card: FC<CardProps> = ({ isHoverable = false, children }) => {
     return (
-        <div data-test-id="card" className="tw-w-full tw-bg-white tw-border tw-border-black-10 tw-rounded">
+        <div
+            data-test-id="card"
+            className={merge([
+                "tw-w-full tw-bg-white tw-border tw-border-black-10 tw-rounded",
+                isHoverable ? "hover:tw-border-black" : "",
+            ])}
+        >
             {children}
         </div>
     );


### PR DESCRIPTION
Adds an optional `isHoverable` prop to the `Card` component to support the Brand Listening card design.