### PR TITLE
feat(Accordion): add padding option

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -93,6 +93,16 @@ export const WithDifferentAccordionItems: Story<AccordionProps> = () => {
                 </div>
                 <Button onClick={() => setShowContent(!showContent)}>Toggle Content</Button>
             </AccordionItem>
+            <AccordionItem
+                header={{ children: "Item without padding", type: FieldsetHeaderType.AddRemove }}
+                noPadding={true}
+            >
+                <p>
+                    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+                    labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+                    et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+                </p>
+            </AccordionItem>
         </AccordionComponent>
     );
 };

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -95,7 +95,7 @@ export const WithDifferentAccordionItems: Story<AccordionProps> = () => {
             </AccordionItem>
             <AccordionItem
                 header={{ children: "Item without padding", type: FieldsetHeaderType.AddRemove }}
-                noPadding={true}
+                padding={false}
             >
                 <p>
                     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -8,6 +8,7 @@ import { Item as StatelyItem } from "@react-stately/collections";
 import { TreeState, useTreeState } from "@react-stately/tree";
 import { Node } from "@react-types/shared";
 import { FOCUS_STYLE_INSET } from "@utilities/focusStyle";
+import { merge } from "@utilities/merge";
 import { AnimatePresence, motion } from "framer-motion";
 import React, {
     Children,
@@ -32,7 +33,7 @@ type AriaAccordionItemProps = {
     padding?: boolean;
 };
 
-const AriaAccordionItem: FC<AriaAccordionItemProps> = ({ item, state, header, padding }) => {
+const AriaAccordionItem: FC<AriaAccordionItemProps> = ({ item, state, header, padding = true }) => {
     const triggerRef = useRef<HTMLButtonElement | null>(null);
     const { buttonProps, regionProps } = useAccordionItem({ item }, state, triggerRef);
     const isOpen = state.expandedKeys.has(item.key) && item.props.children;
@@ -81,7 +82,7 @@ const AriaAccordionItem: FC<AriaAccordionItemProps> = ({ item, state, header, pa
                         transition={{ type: "tween" }}
                         data-test-id="accordion-item-content"
                     >
-                        <div {...regionProps} className={`tw-pb-6 ${padding === false ? "" : "tw-px-8"}`}>
+                        <div {...regionProps} className={merge(["tw-pb-6", padding && "tw-px-8"])}>
                             <motion.div
                                 initial={{ opacity: 0 }}
                                 animate={{ opacity: 1 }}

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -20,7 +20,7 @@ import React, {
     useRef,
 } from "react";
 
-export type AccordionItemProps = PropsWithChildren<{ header: FieldsetHeaderProps }>;
+export type AccordionItemProps = PropsWithChildren<{ header: FieldsetHeaderProps; noPadding?: boolean }>;
 
 const ACCORDION_ID = "accordion";
 const ACCORDION_ITEM_ID = "accordion-item";
@@ -29,9 +29,10 @@ type AriaAccordionItemProps = {
     item: Node<AccordionItemProps>;
     state: TreeState<AccordionItemProps>;
     header: FieldsetHeaderProps;
+    noPadding?: boolean;
 };
 
-const AriaAccordionItem: FC<AriaAccordionItemProps> = ({ item, state, header }) => {
+const AriaAccordionItem: FC<AriaAccordionItemProps> = ({ item, state, header, noPadding }) => {
     const triggerRef = useRef<HTMLButtonElement | null>(null);
     const { buttonProps, regionProps } = useAccordionItem({ item }, state, triggerRef);
     const isOpen = state.expandedKeys.has(item.key) && item.props.children;
@@ -80,7 +81,7 @@ const AriaAccordionItem: FC<AriaAccordionItemProps> = ({ item, state, header }) 
                         transition={{ type: "tween" }}
                         data-test-id="accordion-item-content"
                     >
-                        <div {...regionProps} className="tw-px-8 tw-pb-6">
+                        <div {...regionProps} className={`tw-pb-6 ${noPadding ? "" : "tw-px-8"}`}>
                             <motion.div
                                 initial={{ opacity: 0 }}
                                 animate={{ opacity: 1 }}
@@ -164,9 +165,10 @@ export const Accordion: FC<AccordionProps> = (props) => {
             className="tw-divide-y tw-divide-black-10 tw-border-t tw-border-b tw-border-black-10"
         >
             {[...state.collection].map((item, index) => {
-                const { header } = children[index].props;
-
-                return <AriaAccordionItem key={item.key} item={item} state={state} header={header} />;
+                const { header, noPadding } = children[index].props;
+                return (
+                    <AriaAccordionItem key={item.key} item={item} state={state} header={header} noPadding={noPadding} />
+                );
             })}
         </div>
     );

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -20,7 +20,7 @@ import React, {
     useRef,
 } from "react";
 
-export type AccordionItemProps = PropsWithChildren<{ header: FieldsetHeaderProps; noPadding?: boolean }>;
+export type AccordionItemProps = PropsWithChildren<{ header: FieldsetHeaderProps; padding?: boolean }>;
 
 const ACCORDION_ID = "accordion";
 const ACCORDION_ITEM_ID = "accordion-item";
@@ -29,10 +29,10 @@ type AriaAccordionItemProps = {
     item: Node<AccordionItemProps>;
     state: TreeState<AccordionItemProps>;
     header: FieldsetHeaderProps;
-    noPadding?: boolean;
+    padding?: boolean;
 };
 
-const AriaAccordionItem: FC<AriaAccordionItemProps> = ({ item, state, header, noPadding }) => {
+const AriaAccordionItem: FC<AriaAccordionItemProps> = ({ item, state, header, padding }) => {
     const triggerRef = useRef<HTMLButtonElement | null>(null);
     const { buttonProps, regionProps } = useAccordionItem({ item }, state, triggerRef);
     const isOpen = state.expandedKeys.has(item.key) && item.props.children;
@@ -81,7 +81,7 @@ const AriaAccordionItem: FC<AriaAccordionItemProps> = ({ item, state, header, no
                         transition={{ type: "tween" }}
                         data-test-id="accordion-item-content"
                     >
-                        <div {...regionProps} className={`tw-pb-6 ${noPadding ? "" : "tw-px-8"}`}>
+                        <div {...regionProps} className={`tw-pb-6 ${padding === false ? "" : "tw-px-8"}`}>
                             <motion.div
                                 initial={{ opacity: 0 }}
                                 animate={{ opacity: 1 }}
@@ -165,10 +165,8 @@ export const Accordion: FC<AccordionProps> = (props) => {
             className="tw-divide-y tw-divide-black-10 tw-border-t tw-border-b tw-border-black-10"
         >
             {[...state.collection].map((item, index) => {
-                const { header, noPadding } = children[index].props;
-                return (
-                    <AriaAccordionItem key={item.key} item={item} state={state} header={header} noPadding={noPadding} />
-                );
+                const { header, padding } = children[index].props;
+                return <AriaAccordionItem key={item.key} item={item} state={state} header={header} padding={padding} />;
             })}
         </div>
     );


### PR DESCRIPTION
This PR adds an option to have the content inside an accordion without left & right padding. This is need for the scroll-area in the targets selection.

![Settings panel Accordion (2)](https://user-images.githubusercontent.com/11270687/152539112-4f6058ce-c6d5-448a-8d8e-50336e3b26a8.jpg)
