### PR TITLE
feat: button rounded property

### DIFF
--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -3,7 +3,7 @@
 import { mount } from "@cypress/react";
 import IconIcons from "@foundation/Icon/Generated/IconIcons";
 import React from "react";
-import { Button, ButtonSize, ButtonStyle } from "./Button";
+import { Button, ButtonRounding, ButtonSize, ButtonStyle } from "./Button";
 
 const BUTTON_TEXT = "Frontify";
 export const BUTTON_ID = "[data-test-id=button]";
@@ -45,6 +45,24 @@ describe("Button component", () => {
 
                     cy.get(BUTTON_ID).children("svg").should("be.visible");
                     cy.get(BUTTON_ID).should("not.contain", BUTTON_TEXT);
+                });
+
+                it(`renders in ${style} ${size} and ${
+                    solid ? "solid" : "translucent"
+                } with only an icon and fully rounded.`, () => {
+                    mount(
+                        <Button
+                            style={style}
+                            size={size}
+                            solid={solid}
+                            icon={<IconIcons />}
+                            rounding={ButtonRounding.Full}
+                        />,
+                    );
+
+                    cy.get(BUTTON_ID).children("svg").should("be.visible");
+                    cy.get(BUTTON_ID).should("not.contain", BUTTON_TEXT);
+                    cy.get(BUTTON_ID).should("have.class", "tw-rounded-full");
                 });
 
                 it(`renders in ${style} ${size} and ${solid ? "solid" : "translucent"} with an icon and text.`, () => {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,8 +2,8 @@
 
 import React from "react";
 import { Meta, Story } from "@storybook/react";
-import { Button, ButtonProps, ButtonSize, ButtonStyle, ButtonType } from "./Button";
-import IconIcons from "@foundation/Icon/Generated/IconIcons";
+import { Button, ButtonProps, ButtonRounding, ButtonSize, ButtonStyle, ButtonType } from "./Button";
+import { IconIcons, IconActions } from "@foundation/Icon/Generated";
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -20,6 +20,10 @@ export default {
         },
         style: {
             options: [ButtonStyle.Primary, ButtonStyle.Secondary, ButtonStyle.Danger, ButtonStyle.Positive],
+            control: { type: "select" },
+        },
+        rounding: {
+            options: [ButtonRounding.Medium, ButtonRounding.Full],
             control: { type: "select" },
         },
         type: {
@@ -53,6 +57,18 @@ withIcon.args = {
     type: ButtonType.Button,
 };
 withIcon.storyName = "Icon Only";
+
+export const withRoundedIcon = ButtonTemplate.bind({});
+withRoundedIcon.args = {
+    disabled: false,
+    icon: <IconActions />,
+    size: ButtonSize.Medium,
+    rounding: ButtonRounding.Full,
+    solid: true,
+    style: ButtonStyle.Secondary,
+    type: ButtonType.Button,
+};
+withRoundedIcon.storyName = "Icon Only rounded";
 
 export const withIconAndLabel = ButtonTemplate.bind({});
 withIconAndLabel.args = {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -27,6 +27,11 @@ export enum ButtonType {
     Reset = "Reset",
 }
 
+export enum ButtonRounding {
+    Medium = "Medium",
+    Full = "Full",
+}
+
 const sizeClasses: Record<ButtonSize, string> = {
     [ButtonSize.Small]: "tw-px-3 tw-h-6 tw-text-xs",
     [ButtonSize.Medium]: "tw-px-4 tw-h-9 tw-text-s",
@@ -37,6 +42,12 @@ const iconOnlySizeClasses: Record<ButtonSize, string> = {
     [ButtonSize.Small]: "tw-p-1",
     [ButtonSize.Medium]: "tw-p-2",
     [ButtonSize.Large]: "tw-p-3",
+};
+
+const iconOnlyFullRoundingSizeClasses: Record<ButtonSize, string> = {
+    [ButtonSize.Small]: "tw-p-0.5",
+    [ButtonSize.Medium]: "tw-p-1",
+    [ButtonSize.Large]: "tw-p-2",
 };
 
 const iconSpacing: Record<ButtonSize, string> = {
@@ -91,6 +102,7 @@ export type ButtonProps = {
     type?: ButtonType;
     style?: ButtonStyle;
     size?: ButtonSize;
+    rounding?: ButtonRounding;
     solid?: boolean;
     inverted?: boolean;
     disabled?: boolean;
@@ -104,6 +116,7 @@ export const Button: FC<ButtonProps> = ({
     type = ButtonType.Button,
     style = ButtonStyle.Primary,
     size = ButtonSize.Medium,
+    rounding = ButtonRounding.Medium,
     solid = true,
     inverted = false,
     disabled = false,
@@ -133,8 +146,12 @@ export const Button: FC<ButtonProps> = ({
             {...mergeProps(buttonProps, focusProps)}
             ref={ref}
             className={merge([
-                "tw-outline-none tw-relative tw-flex tw-items-center tw-justify-center tw-border-0 tw-rounded tw-cursor-pointer tw-font-sans tw-transition-colors",
-                icon && !children ? iconOnlySizeClasses[size] : sizeClasses[size],
+                "tw-outline-none tw-relative tw-flex tw-items-center tw-justify-center tw-border-0 tw-cursor-pointer tw-font-sans tw-transition-colors",
+                rounding === ButtonRounding.Full
+                    ? `tw-rounded-full ${iconOnlyFullRoundingSizeClasses[size]}`
+                    : "tw-rounded",
+                rounding === ButtonRounding.Medium &&
+                    (icon && !children ? iconOnlySizeClasses[size] : sizeClasses[size]),
                 merge(
                     disabled
                         ? [


### PR DESCRIPTION
This change introduces the property to render a button with a fully rounded radius. We need this to reflect the design of the legacy component `IconButton`, which was heavily used as a trigger for settings- and actions-menus, etc. Unless we have migrated all its occurrences to React, we can't easily switch to the new square design. As soon as we can switch to the new design, this property will be removed.