### PR TITLE
fix(link-chooser): keyboard navigation on extra panels

### DIFF
--- a/src/components/LinkChooser/LinkChooser.spec.tsx
+++ b/src/components/LinkChooser/LinkChooser.spec.tsx
@@ -284,6 +284,15 @@ describe("LinkChooser Component", () => {
             cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
         });
 
+        it("hides dropdown on escape", () => {
+            mount(getLinkChooserComponent());
+
+            cy.get(SEARCH_WRAPPER_ID).click();
+            cy.get(DROPDOWN_WRAPPER_ID).should("exist");
+            cy.get(SEARCH_INPUT_ID).realPress("Escape");
+            cy.get(DROPDOWN_WRAPPER_ID).should("not.exist");
+        });
+
         it("adds selected item to local storage", () => {
             mount(getLinkChooserComponent());
 
@@ -588,19 +597,17 @@ describe("LinkChooser Component", () => {
             cy.get(MENU_ITEM).eq(1).should("have.class", FOCUSED_OPTION_CLASS).and("have.text", TEMPLATE_TITLE);
             cy.get(SEARCH_INPUT_ID).realPress("Enter");
             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
+            cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
+            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
             cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
-            cy.get("@firstSelectItem").should("contain.text", FIRST_TEMPLATE_TITLE);
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-            cy.get(MENU_ITEM).first().should("have.text", TEMPLATE_TITLE);
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
-            cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
-            cy.get(SEARCH_INPUT_ID).realPress("Escape");
-            //TODO: add back button test section as soon as keyboard-navigation is fixed
-            // cy.get(SEARCH_INPUT_ID).realPress("ArrowUp");
-            // cy.get(`@firstSelectItem`).should("not.have.class", FOCUSED_OPTION_CLASS);
-            // cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS);
-            // cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
-            // cy.get(EMPTY_RESULTS_ID).should("be.visible");
+            cy.get("@firstSelectItem")
+                .should("contain.text", FIRST_TEMPLATE_TITLE)
+                .and("have.class", FOCUSED_OPTION_CLASS);
+            cy.get(SEARCH_INPUT_ID).realPress("ArrowUp");
+            cy.get(MENU_ITEM).first().should("have.class", FOCUSED_OPTION_CLASS).and("have.text", TEMPLATE_TITLE);
+            cy.get(SEARCH_INPUT_ID).realPress("Enter");
+            cy.get(EMPTY_RESULTS_ID).should("be.visible");
+            cy.get(MENU_ITEM).eq(1).should("have.text", TEMPLATE_TITLE).and("have.class", FOCUSED_OPTION_CLASS);
             cy.get(SEARCH_INPUT_ID).type(data[0].title);
             cy.get(`@firstSelectItem`)
                 .should("not.have.class", FOCUSED_OPTION_CLASS)

--- a/src/components/LinkChooser/LinkChooser.spec.tsx
+++ b/src/components/LinkChooser/LinkChooser.spec.tsx
@@ -708,7 +708,7 @@ describe("LinkChooser Component", () => {
                 .should("contain", JSON.parse(localStorage.getItem(QUERIES_STORAGE_KEY) || "null")[0].title);
         });
 
-        it.only("can be navigated to by keyboard", () => {
+        it("can be navigated to by keyboard", () => {
             mount(getLinkChooserComponent());
             cy.window().focus();
             cy.get("body").realPress("Tab");
@@ -718,7 +718,6 @@ describe("LinkChooser Component", () => {
             cy.get(DROPDOWN_WRAPPER_ID).should("be.visible");
             cy.get(`${SELECT_SECTION_ID} > li`).first().as("firstSelectItem");
             cy.get("@firstSelectItem").should("contain.text", FIRST_GUIDELINE_TITLE);
-            cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
             cy.get(SEARCH_INPUT_ID).realPress("ArrowDown");
             cy.get(`@firstSelectItem`).should("have.class", FOCUSED_OPTION_CLASS);
             cy.get(SEARCH_INPUT_ID).realPress("Enter");

--- a/src/components/LinkChooser/LinkChooser.tsx
+++ b/src/components/LinkChooser/LinkChooser.tsx
@@ -73,18 +73,18 @@ export const LinkChooser: FC<LinkChooserProps> = ({
         }),
     );
 
-    const isDefault = shouldGoBack(matches);
+    const isDefault = !shouldGoBack(matches);
     const searchResultMenuBlocks = useMemo(
         () =>
             [
-                isDefault && { id: "menu-top", menuItems: [defaultSection] },
+                !isDefault && { id: "menu-top", menuItems: [findSection(extraSections, context.currentSectionId)] },
                 {
                     id: "search",
                     menuItems: decoratedResults(context.searchResults),
                 },
-                !isDefault && { id: "menu-bottom", menuItems: extraSections.map(({ id, title }) => ({ id, title })) },
+                isDefault && { id: "menu-bottom", menuItems: extraSections.map(({ id, title }) => ({ id, title })) },
             ].filter(Boolean),
-        [context.searchResults, isDefault],
+        [context.searchResults, isDefault, context.currentSectionId],
     ) as SearchMenuBlock[];
 
     const props = mapToAriaProps(ariaLabel, searchResultMenuBlocks);
@@ -179,17 +179,26 @@ export const LinkChooser: FC<LinkChooserProps> = ({
             onOpen: handleDropdownOpen,
             onClose: handleDropdownClose,
             onNavigate: (id) => {
-                send({
-                    type: "SELECT_EXTRA_SECTION",
-                    data: {
-                        getExtraResultsByQuery: findSection(extraSections, id)?.getResults || null,
-                        currentSectionId: id.toString(),
-                    },
-                });
+                console.log(isDefault);
+                if (isDefault) {
+                    send({
+                        type: "SELECT_EXTRA_SECTION",
+                        data: {
+                            getExtraResultsByQuery: findSection(extraSections, id)?.getResults || null,
+                            currentSectionId: id.toString(),
+                        },
+                    });
+                } else {
+                    send({
+                        type: "BACK_TO_DEFAULT",
+                        data: { getExtraResultsByQuery: null },
+                    });
+                }
             },
             onSelect: handleSelectionChange,
         },
     );
+
     const inputDecorator = IconOptions[context.selectedResult?.icon || DEFAULT_ICON];
 
     useEffect(() => {

--- a/src/components/LinkChooser/LinkChooser.tsx
+++ b/src/components/LinkChooser/LinkChooser.tsx
@@ -179,7 +179,6 @@ export const LinkChooser: FC<LinkChooserProps> = ({
             onOpen: handleDropdownOpen,
             onClose: handleDropdownClose,
             onNavigate: (id) => {
-                console.log(isDefault);
                 if (isDefault) {
                     send({
                         type: "SELECT_EXTRA_SECTION",

--- a/src/components/LinkChooser/SearchResultOption.tsx
+++ b/src/components/LinkChooser/SearchResultOption.tsx
@@ -7,7 +7,7 @@ import { useActor } from "@xstate/react";
 import React, { FC, useRef } from "react";
 import { IconOptions } from "./LinkChooser";
 import { DropdownState, LinkChooserState, SectionState } from "./state/machine";
-import { ImageMenuItemProps, SearchResultOptionProps } from "./types";
+import { ImageMenuItemProps, SearchResultOptionProps, SearchResult } from "./types";
 import { findSection } from "./utils/helpers";
 
 export const SearchResultOption: FC<SearchResultOptionProps> = ({ item, state, keyItemRecord, machineService }) => {
@@ -35,6 +35,9 @@ export const SearchResultOption: FC<SearchResultOptionProps> = ({ item, state, k
 
     const isFocusVisible = getInteractionModality() !== "pointer";
 
+    const renderExtraSection = (menuItem: SearchResult) =>
+        currentSection?.renderPreview?.(menuItem) || <ImageMenuItem {...menuItem} />;
+
     return (
         <li
             {...optionProps}
@@ -45,13 +48,10 @@ export const SearchResultOption: FC<SearchResultOptionProps> = ({ item, state, k
                 isFocused && isFocusVisible && "tw-bg-black-0",
             ])}
         >
-            {isLoaded(DropdownState.Default) ? (
+            {isLoaded(DropdownState.Default) && (
                 <MenuItem {...menuItem} active={isSelected} decorator={decorator} size={MenuItemContentSize.Large} />
-            ) : isLoaded(DropdownState.ExtraSection) && currentSection?.renderPreview ? (
-                currentSection.renderPreview(menuItem)
-            ) : (
-                <ImageMenuItem {...menuItem} />
             )}
+            {isLoaded(DropdownState.ExtraSection) && renderExtraSection(menuItem)}
         </li>
     );
 };


### PR DESCRIPTION
Fix for: https://app.clickup.com/t/24g28a0

- Menu navigation in extra sections is now possible
- Refactored search result option to avoid a visual glitch that would display ImageMenuItem components momentarily when closing the dropdown