### PR TITLE
fix: change hover and focus color for search results in LinkChooser

### DIFF
--- a/src/components/LinkChooser/LinkChooser.spec.tsx
+++ b/src/components/LinkChooser/LinkChooser.spec.tsx
@@ -36,7 +36,7 @@ const MENU_ITEM = "[data-test-id='link-chooser-navigation-menu-item']";
 const DEFAULT_TIMEOUT = 100;
 const CUSTOM_QUERY = "Custom link";
 const SELECTED_CLASS = "tw-text-violet-60";
-const FOCUSED_OPTION_CLASS = "tw-bg-black-0";
+const FOCUSED_OPTION_CLASS = "tw-bg-black-10";
 const TEMPLATE_TITLE = templateSection.title;
 const GUIDELINE_TITLE = guidelineSection.title;
 const FIRST_TEMPLATE_TITLE = templateSection.items[0].title;

--- a/src/components/LinkChooser/NavigationMenu.tsx
+++ b/src/components/LinkChooser/NavigationMenu.tsx
@@ -67,7 +67,7 @@ export const NavigationMenuItem: FC<NavigationMenuItemProps> = ({
             aria-label={`Navigate to ${id} section of search results.`}
             data-key={id}
             data-test-id="link-chooser-navigation-menu-item"
-            className={merge(["hover:tw-bg-black-0", isFocused && isFocusVisible && "tw-bg-black-0"])}
+            className={merge(["hover:tw-bg-black-10", isFocused && isFocusVisible && "tw-bg-black-10"])}
         >
             <MenuItem
                 title={itemTitle}

--- a/src/components/LinkChooser/SearchResultOption.tsx
+++ b/src/components/LinkChooser/SearchResultOption.tsx
@@ -40,9 +40,9 @@ export const SearchResultOption: FC<SearchResultOptionProps> = ({ item, state, k
             {...optionProps}
             ref={ref}
             className={merge([
-                "tw-relative hover:tw-bg-black-0 tw-list-none tw-outline-none",
+                "tw-relative hover:tw-bg-black-10 tw-list-none tw-outline-none",
                 isDisabled && "tw-pointer-events-none tw-top-px",
-                isFocused && isFocusVisible && "tw-bg-black-0",
+                isFocused && isFocusVisible && "tw-bg-black-10",
             ])}
         >
             {isLoaded(DropdownState.Default) ? (


### PR DESCRIPTION
Concerns this ticket: https://app.clickup.com/t/2329n7k

Adds a darker background color for hover and focus styles