### PR TITLE
feat(text/header): Add new typography props to text and header

### DIFF
--- a/src/typography/Heading/Heading.spec.tsx
+++ b/src/typography/Heading/Heading.spec.tsx
@@ -3,6 +3,25 @@
 import React from "react";
 import { mount } from "@cypress/react";
 import { Heading } from "./Heading";
+import { HeadingProps } from ".";
+
+const classRecord = {
+    color: ["warning", "tw-text-text-warning"],
+    overflow: ["truncate", "tw-truncate"],
+    whitespace: ["pre", "tw-whitespace-pre"],
+    display: ["inline-block", "tw-inline-block"],
+    wordBreak: ["break-all", "tw-break-all"],
+    decoration: ["underline", "tw-underline"],
+    size: ["large", "tw-text-heading-large"],
+    weight: ["strong", "tw-font-bold"],
+};
+
+const headingProps = Object.entries(classRecord).reduce((acc, [key, [value]]) => {
+    //eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    acc[key] = value;
+    return acc as HeadingProps;
+}, {} as HeadingProps);
 
 describe("Heading", () => {
     it("should render headings as span by default", () => {
@@ -15,5 +34,15 @@ describe("Heading", () => {
         mount(<Heading as="h1">The fox jumps over the lazy dog</Heading>);
 
         cy.get("[data-test-id=heading]").should((el) => el.attr("tagName") === "H1");
+    });
+
+    it("should add correct classes to element", () => {
+        mount(<Heading {...headingProps}>The fox jumps over the lazy dog</Heading>);
+
+        cy.get("[data-test-id=heading]").should((el) => {
+            Object.values(classRecord).forEach((value) => {
+                expect(el).to.have.class(value[1]);
+            });
+        });
     });
 });

--- a/src/typography/Heading/Heading.spec.tsx
+++ b/src/typography/Heading/Heading.spec.tsx
@@ -7,7 +7,7 @@ import { HeadingProps } from ".";
 
 const classRecord = {
     color: ["warning", "tw-text-text-warning"],
-    overflow: ["truncate", "tw-truncate"],
+    overflow: ["clip", "tw-text-clip"],
     whitespace: ["pre", "tw-whitespace-pre"],
     display: ["inline-block", "tw-inline-block"],
     wordBreak: ["break-all", "tw-break-all"],

--- a/src/typography/Heading/Heading.spec.tsx
+++ b/src/typography/Heading/Heading.spec.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { mount } from "@cypress/react";
 import { Heading } from "./Heading";
-import { HeadingProps } from ".";
 
 const classRecord = {
     color: ["warning", "tw-text-text-warning"],
@@ -17,11 +16,9 @@ const classRecord = {
 };
 
 const headingProps = Object.entries(classRecord).reduce((acc, [key, [value]]) => {
-    //eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     acc[key] = value;
-    return acc as HeadingProps;
-}, {} as HeadingProps);
+    return acc;
+}, {} as Record<string, string>);
 
 describe("Heading", () => {
     it("should render headings as span by default", () => {

--- a/src/typography/Heading/Heading.stories.tsx
+++ b/src/typography/Heading/Heading.stories.tsx
@@ -2,7 +2,7 @@
 
 import { Meta, Story } from "@storybook/react";
 import React from "react";
-import { SharedTypographyArgTypes } from "../shared/Shared.stories";
+import { sharedTypographyArgs, sharedTypographyArgTypes } from "../shared/Shared.stories";
 import { Heading as HeadingComponent, HeadingProps } from "./Heading";
 
 // eslint-disable-next-line import/no-default-export
@@ -26,7 +26,7 @@ export default {
             options: ["default", "weak", "x-weak", "disabled", "negative", "positive", "warning", "interactive"],
             control: { type: "select" },
         },
-        ...SharedTypographyArgTypes,
+        ...sharedTypographyArgTypes,
     },
     args: {
         children: "The fox jumps over the lazy dog",
@@ -34,6 +34,7 @@ export default {
         weight: "medium",
         as: "span",
         color: "default",
+        ...sharedTypographyArgs,
     },
 } as Meta<HeadingProps>;
 

--- a/src/typography/Heading/Heading.stories.tsx
+++ b/src/typography/Heading/Heading.stories.tsx
@@ -2,6 +2,7 @@
 
 import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { SharedTypographyArgTypes } from "../shared/Shared.stories";
 import { Heading as HeadingComponent, HeadingProps } from "./Heading";
 
 // eslint-disable-next-line import/no-default-export
@@ -25,6 +26,7 @@ export default {
             options: ["default", "weak", "x-weak", "disabled", "negative", "positive", "warning", "interactive"],
             control: { type: "select" },
         },
+        ...SharedTypographyArgTypes,
     },
     args: {
         children: "The fox jumps over the lazy dog",
@@ -35,4 +37,13 @@ export default {
     },
 } as Meta<HeadingProps>;
 
-export const Heading: Story<HeadingProps> = (args) => <HeadingComponent {...args} />;
+export const DefaultHeading: Story<HeadingProps> = (args) => <HeadingComponent {...args} />;
+
+export const LongHeadingWithNewLines: Story<HeadingProps> = (args) => (
+    <div className="tw-w-[200px] tw-p-2 tw-rounded tw-border">
+        <HeadingComponent {...args}>
+            {`Heading with veryveryveryveryveryextremelyhugelymassivelysuperlengthygiganticwords and limited width.\nThis is to display
+            the different types of overflow control available.`}
+        </HeadingComponent>
+    </div>
+);

--- a/src/typography/Heading/Heading.tsx
+++ b/src/typography/Heading/Heading.tsx
@@ -61,7 +61,7 @@ export const Heading: FC<HeadingProps> = ({
             colorMap[color],
             decorationMap[decoration],
             wordBreakMap[wordBreak],
-            whitespaceMap[whitespace],
+            overflow !== "truncate" && whitespaceMap[whitespace],
             overflowMap[overflow],
             display && displayMap[display],
         ])}

--- a/src/typography/Heading/Heading.tsx
+++ b/src/typography/Heading/Heading.tsx
@@ -2,17 +2,21 @@
 
 import { merge } from "@utilities/merge";
 import React, { FC, PropsWithChildren } from "react";
+import { decorationMap, displayMap, overflowMap, whitespaceMap, wordBreakMap } from "../shared/records";
+import { SharedTypographyProps } from "../shared/types";
 
 type HeadingWeight = "medium" | "strong";
 type HeadingSize = "medium" | "large" | "x-large";
 type HeadingColor = "default" | "weak" | "x-weak" | "disabled" | "negative" | "positive" | "warning" | "interactive";
 
-export type HeadingProps = PropsWithChildren<{
-    size?: HeadingSize;
-    weight?: HeadingWeight;
-    as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "span" | "p";
-    color?: HeadingColor;
-}>;
+export type HeadingProps = PropsWithChildren<
+    SharedTypographyProps & {
+        size?: HeadingSize;
+        weight?: HeadingWeight;
+        as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "span" | "p";
+        color?: HeadingColor;
+    }
+>;
 
 const weightMap: Record<HeadingWeight, string> = {
     medium: "tw-font-medium",
@@ -42,13 +46,26 @@ export const Heading: FC<HeadingProps> = ({
     weight = "medium",
     size = "medium",
     color = "default",
-}) => {
-    return (
-        <Tag
-            data-test-id="heading"
-            className={merge(["tw-font-heading", weightMap[weight], sizeMap[size], colorMap[color]])}
-        >
-            {children}
-        </Tag>
-    );
-};
+    overflow = "ellipsis",
+    decoration = "none",
+    whitespace,
+    display,
+    wordBreak,
+}) => (
+    <Tag
+        data-test-id="heading"
+        className={merge([
+            "tw-font-heading tw-max-w-full",
+            weightMap[weight],
+            sizeMap[size],
+            colorMap[color],
+            overflowMap[overflow],
+            decorationMap[decoration],
+            whitespace && whitespaceMap[whitespace],
+            display && displayMap[display],
+            wordBreak && wordBreakMap[wordBreak],
+        ])}
+    >
+        {children}
+    </Tag>
+);

--- a/src/typography/Heading/Heading.tsx
+++ b/src/typography/Heading/Heading.tsx
@@ -46,11 +46,11 @@ export const Heading: FC<HeadingProps> = ({
     weight = "medium",
     size = "medium",
     color = "default",
-    overflow = "ellipsis",
+    overflow = "visible",
     decoration = "none",
-    whitespace,
+    wordBreak = "normal",
+    whitespace = "normal",
     display,
-    wordBreak,
 }) => (
     <Tag
         data-test-id="heading"
@@ -59,11 +59,11 @@ export const Heading: FC<HeadingProps> = ({
             weightMap[weight],
             sizeMap[size],
             colorMap[color],
-            overflowMap[overflow],
             decorationMap[decoration],
-            whitespace && whitespaceMap[whitespace],
+            wordBreakMap[wordBreak],
+            whitespaceMap[whitespace],
+            overflowMap[overflow],
             display && displayMap[display],
-            wordBreak && wordBreakMap[wordBreak],
         ])}
     >
         {children}

--- a/src/typography/Text/Text.spec.tsx
+++ b/src/typography/Text/Text.spec.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { mount } from "@cypress/react";
 import { Text } from "./Text";
-import { TextProps } from ".";
 
 const classRecord = {
     color: ["weak", "tw-text-text-weak"],
@@ -17,11 +16,9 @@ const classRecord = {
 };
 
 const textProps = Object.entries(classRecord).reduce((acc, [key, [value]]) => {
-    //eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
     acc[key] = value;
-    return acc as TextProps;
-}, {} as TextProps);
+    return acc;
+}, {} as Record<string, string>);
 
 describe("Text", () => {
     it("should render text as span by default", () => {

--- a/src/typography/Text/Text.spec.tsx
+++ b/src/typography/Text/Text.spec.tsx
@@ -3,17 +3,50 @@
 import React from "react";
 import { mount } from "@cypress/react";
 import { Text } from "./Text";
+import { TextProps } from ".";
+
+const classRecord = {
+    color: ["weak", "tw-text-text-weak"],
+    overflow: ["ellipsis", "tw-text-ellipsis"],
+    whitespace: ["nowrap", "tw-whitespace-nowrap"],
+    display: ["block", "tw-block"],
+    wordBreak: ["break-all", "tw-break-all"],
+    decoration: ["underline", "tw-underline"],
+    size: ["small", "tw-text-body-small"],
+    weight: ["strong", "tw-font-bold"],
+};
+
+const textProps = Object.entries(classRecord).reduce((acc, [key, [value]]) => {
+    //eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    acc[key] = value;
+    return acc as TextProps;
+}, {} as TextProps);
 
 describe("Text", () => {
     it("should render text as span by default", () => {
         mount(<Text>The fox jumps over the lazy dog</Text>);
 
-        cy.get("[data-test-id=heading]").should((el) => el.attr("tagName") === "SPAN");
+        cy.get("[data-test-id=text]").should((el) => el.attr("tagName") === "SPAN");
     });
 
     it("should render text as h1 p provided", () => {
         mount(<Text as="p">The fox jumps over the lazy dog</Text>);
 
-        cy.get("[data-test-id=heading]").should((el) => el.attr("tagName") === "P");
+        cy.get("[data-test-id=text]").should((el) => el.attr("tagName") === "P");
+    });
+
+    it("should add correct classes to element", () => {
+        mount(
+            <Text as="p" {...textProps}>
+                The fox jumps over the lazy dog
+            </Text>,
+        );
+
+        cy.get("[data-test-id=text]").should((el) => {
+            Object.values(classRecord).forEach((value) => {
+                expect(el).to.have.class(value[1]);
+            });
+        });
     });
 });

--- a/src/typography/Text/Text.stories.tsx
+++ b/src/typography/Text/Text.stories.tsx
@@ -2,6 +2,7 @@
 
 import { Meta, Story } from "@storybook/react";
 import React from "react";
+import { SharedTypographyArgTypes } from "../shared/Shared.stories";
 import { Text as TextComponent, TextProps } from "./Text";
 
 // eslint-disable-next-line import/no-default-export
@@ -25,6 +26,7 @@ export default {
             options: ["default", "weak", "x-weak", "disabled", "negative", "positive", "warning", "interactive"],
             control: { type: "select" },
         },
+        ...SharedTypographyArgTypes,
     },
     args: {
         children: "The fox jumps over the lazy dog",
@@ -35,4 +37,13 @@ export default {
     },
 } as Meta<TextProps>;
 
-export const Text: Story<TextProps> = (args) => <TextComponent {...args} />;
+export const DefaultText: Story<TextProps> = (args) => <TextComponent {...args} />;
+
+export const LongTextWithNewLines: Story<TextProps> = (args) => (
+    <div className="tw-w-[200px] tw-p-2 tw-rounded tw-border">
+        <TextComponent {...args}>
+            {`Text with veryveryveryveryveryextremelyhugelymassivelysuperlengthygiganticwords and limited width.\nThis is to display
+            the different types of overflow control available.`}
+        </TextComponent>
+    </div>
+);

--- a/src/typography/Text/Text.stories.tsx
+++ b/src/typography/Text/Text.stories.tsx
@@ -2,7 +2,7 @@
 
 import { Meta, Story } from "@storybook/react";
 import React from "react";
-import { SharedTypographyArgTypes } from "../shared/Shared.stories";
+import { sharedTypographyArgs, sharedTypographyArgTypes } from "../shared/Shared.stories";
 import { Text as TextComponent, TextProps } from "./Text";
 
 // eslint-disable-next-line import/no-default-export
@@ -26,7 +26,7 @@ export default {
             options: ["default", "weak", "x-weak", "disabled", "negative", "positive", "warning", "interactive"],
             control: { type: "select" },
         },
-        ...SharedTypographyArgTypes,
+        ...sharedTypographyArgTypes,
     },
     args: {
         children: "The fox jumps over the lazy dog",
@@ -34,6 +34,7 @@ export default {
         weight: "regular",
         as: "span",
         color: "default",
+        ...sharedTypographyArgs,
     },
 } as Meta<TextProps>;
 

--- a/src/typography/Text/Text.tsx
+++ b/src/typography/Text/Text.tsx
@@ -2,17 +2,21 @@
 
 import { merge } from "@utilities/merge";
 import React, { FC, PropsWithChildren } from "react";
+import { decorationMap, displayMap, overflowMap, whitespaceMap, wordBreakMap } from "../shared/records";
+import { SharedTypographyProps } from "../shared/types";
 
 type TextWeight = "regular" | "strong" | "x-strong";
 type TextSize = "x-small" | "small" | "medium" | "large";
 type TextColor = "default" | "weak" | "x-weak" | "disabled" | "negative" | "positive" | "warning" | "interactive";
 
-export type TextProps = PropsWithChildren<{
-    size?: TextSize;
-    weight?: TextWeight;
-    as?: "a" | "abbr" | "address" | "em" | "label" | "li" | "span" | "strong" | "time" | "p";
-    color?: TextColor;
-}>;
+export type TextProps = PropsWithChildren<
+    SharedTypographyProps & {
+        size?: TextSize;
+        weight?: TextWeight;
+        as?: "a" | "abbr" | "address" | "em" | "label" | "li" | "span" | "strong" | "time" | "p";
+        color?: TextColor;
+    }
+>;
 
 const weightMap: Record<TextWeight, string> = {
     regular: "tw-font-regular",
@@ -44,10 +48,26 @@ export const Text: FC<TextProps> = ({
     weight = "regular",
     size = "medium",
     color = "default",
-}) => {
-    return (
-        <Tag data-test-id="text" className={merge(["tw-font-body", weightMap[weight], sizeMap[size], colorMap[color]])}>
-            {children}
-        </Tag>
-    );
-};
+    decoration = "none",
+    wordBreak = "normal",
+    whitespace,
+    display,
+    overflow,
+}) => (
+    <Tag
+        data-test-id="text"
+        className={merge([
+            "tw-font-body tw-max-w-full",
+            weightMap[weight],
+            sizeMap[size],
+            colorMap[color],
+            decorationMap[decoration],
+            wordBreakMap[wordBreak],
+            whitespace && whitespaceMap[whitespace],
+            display && displayMap[display],
+            overflow && overflowMap[overflow],
+        ])}
+    >
+        {children}
+    </Tag>
+);

--- a/src/typography/Text/Text.tsx
+++ b/src/typography/Text/Text.tsx
@@ -50,9 +50,9 @@ export const Text: FC<TextProps> = ({
     color = "default",
     decoration = "none",
     wordBreak = "normal",
-    whitespace,
+    whitespace = "normal",
+    overflow = "visible",
     display,
-    overflow,
 }) => (
     <Tag
         data-test-id="text"
@@ -63,9 +63,9 @@ export const Text: FC<TextProps> = ({
             colorMap[color],
             decorationMap[decoration],
             wordBreakMap[wordBreak],
-            whitespace && whitespaceMap[whitespace],
+            whitespaceMap[whitespace],
+            overflowMap[overflow],
             display && displayMap[display],
-            overflow && overflowMap[overflow],
         ])}
     >
         {children}

--- a/src/typography/Text/Text.tsx
+++ b/src/typography/Text/Text.tsx
@@ -63,7 +63,7 @@ export const Text: FC<TextProps> = ({
             colorMap[color],
             decorationMap[decoration],
             wordBreakMap[wordBreak],
-            whitespaceMap[whitespace],
+            overflow !== "truncate" && whitespaceMap[whitespace],
             overflowMap[overflow],
             display && displayMap[display],
         ])}

--- a/src/typography/shared/Shared.stories.tsx
+++ b/src/typography/shared/Shared.stories.tsx
@@ -1,0 +1,24 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export const SharedTypographyArgTypes = {
+    overflow: {
+        options: ["ellipsis", "clip", "visible", "truncate"],
+        control: { type: "select" },
+    },
+    whitespace: {
+        options: ["nowrap", "pre-wrap", "pre", "pre-line", "normal"],
+        control: { type: "select" },
+    },
+    display: {
+        options: ["block", "inline-block", "none", "inline"],
+        control: { type: "select" },
+    },
+    wordBreak: {
+        options: ["break-all", "break-words", "normal"],
+        control: { type: "select" },
+    },
+    decoration: {
+        options: ["underline", "line-through", "none"],
+        control: { type: "select" },
+    },
+};

--- a/src/typography/shared/Shared.stories.tsx
+++ b/src/typography/shared/Shared.stories.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-export const SharedTypographyArgTypes = {
+export const sharedTypographyArgTypes = {
     overflow: {
         options: ["ellipsis", "clip", "visible", "truncate"],
         control: { type: "select" },
@@ -21,4 +21,12 @@ export const SharedTypographyArgTypes = {
         options: ["underline", "line-through", "none"],
         control: { type: "select" },
     },
+};
+
+export const sharedTypographyArgs = {
+    overflow: "visible",
+    wordBreak: "normal",
+    decoration: "none",
+    whitespace: "normal",
+    display: "block",
 };

--- a/src/typography/shared/records.ts
+++ b/src/typography/shared/records.ts
@@ -1,0 +1,43 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import {
+    TypographyDecoration,
+    TypographyDisplay,
+    TypographyOverflow,
+    TypographyWhitespace,
+    TypographyWordBreak,
+} from "./types";
+
+export const overflowMap: Record<TypographyOverflow, string> = {
+    truncate: "tw-truncate",
+    ellipsis: "tw-text-ellipsis tw-overflow-hidden",
+    clip: "tw-text-clip tw-overflow-hidden",
+    visible: "tw-overflow-visible",
+};
+
+export const whitespaceMap: Record<TypographyWhitespace, string> = {
+    normal: "tw-whitespace-normal",
+    nowrap: "tw-whitespace-nowrap",
+    pre: "tw-whitespace-pre",
+    "pre-line": "tw-whitespace-pre-line",
+    "pre-wrap": "tw-whitespace-pre-wrap",
+};
+
+export const displayMap: Record<TypographyDisplay, string> = {
+    block: "tw-block",
+    "inline-block": "tw-inline-block",
+    inline: "tw-inline",
+    none: "tw-hidden",
+};
+
+export const wordBreakMap: Record<TypographyWordBreak, string> = {
+    "break-words": "tw-break-words",
+    "break-all": "tw-break-all",
+    normal: "tw-break-normal",
+};
+
+export const decorationMap: Record<TypographyDecoration, string> = {
+    underline: "tw-underline",
+    "line-through": "tw-line-through",
+    none: "tw-no-underline",
+};

--- a/src/typography/shared/types.ts
+++ b/src/typography/shared/types.ts
@@ -1,0 +1,15 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export type SharedTypographyProps = {
+    overflow?: TypographyOverflow;
+    whitespace?: TypographyWhitespace;
+    display?: TypographyDisplay;
+    wordBreak?: TypographyWordBreak;
+    decoration?: TypographyDecoration;
+};
+
+export type TypographyOverflow = "truncate" | "ellipsis" | "clip" | "visible";
+export type TypographyWhitespace = "normal" | "nowrap" | "pre" | "pre-line" | "pre-wrap";
+export type TypographyDisplay = "inline-block" | "block" | "inline" | "none";
+export type TypographyWordBreak = "break-words" | "break-all" | "normal";
+export type TypographyDecoration = "underline" | "line-through" | "none";


### PR DESCRIPTION
Add new controls that would be expected from a text component, including:
- overflow,
- whitespace,
- wordBreak,
- display,
- decoration
All classes correspond almost directly to tailwind classes, with the exception of some additional classes on the overflow control.