### PR TITLE
fix(Breadcrumbs): Move Hook Calls from Loops to Child Components

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -1,7 +1,8 @@
+import { useBreadcrumbItem } from "@react-aria/breadcrumbs";
 import { useFocusRing } from "@react-aria/focus";
 import { mergeProps } from "@react-aria/utils";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
-import React, { forwardRef, HTMLAttributes, RefObject } from "react";
+import React, { FC, RefObject, useRef } from "react";
 import { Breadcrumb } from "./Breadcrumbs";
 
 const Separator = () => (
@@ -20,15 +21,20 @@ const Separator = () => (
 
 type BreadcrumbItemProps = Pick<Breadcrumb, "label" | "link" | "onClick"> & {
     showSeparator: boolean;
-    ariaProps: HTMLAttributes<HTMLElement>;
 };
 
-export const BreadcrumbItem = forwardRef<
-    HTMLAnchorElement | HTMLButtonElement | HTMLSpanElement | null,
-    BreadcrumbItemProps
->(({ label, link, onClick, showSeparator, ariaProps }, ref) => {
+export const BreadcrumbItem: FC<BreadcrumbItemProps> = ({ label, link, onClick, showSeparator }) => {
+    const ref = useRef<HTMLAnchorElement | HTMLButtonElement | HTMLSpanElement | null>(null);
+    const { itemProps } = useBreadcrumbItem(
+        {
+            isCurrent: false,
+            children: label,
+            elementType: link ? "a" : onClick ? "button" : "span",
+        },
+        ref,
+    );
     const { isFocusVisible, focusProps } = useFocusRing();
-    const props = mergeProps(ariaProps, focusProps);
+    const props = mergeProps(itemProps, focusProps);
 
     return (
         <li
@@ -61,6 +67,4 @@ export const BreadcrumbItem = forwardRef<
             {showSeparator && <Separator />}
         </li>
     );
-});
-
-BreadcrumbItem.displayName = "BreadcrumbItem";
+};

--- a/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
@@ -1,7 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { mount } from "@cypress/react";
-import React from "react";
+import React, { FC, useState } from "react";
+import { BreadcrumbsProps } from ".";
 import { Breadcrumbs } from "./Breadcrumbs";
 
 beforeEach("Getting the seperator", () => {
@@ -14,6 +15,24 @@ const BREADCRUMB_ITEMS = [
     { label: "Some second label", link: "/some-second-link" },
     { label: "Some third label", link: "/some-third-link" },
 ];
+
+const ChangingBreadcrumbs: FC<BreadcrumbsProps> = () => {
+    const [items, setItems] = useState(BREADCRUMB_ITEMS);
+
+    return (
+        <div>
+            <Breadcrumbs items={items} />
+            <button
+                data-test-id="add-item-button"
+                onClick={() => {
+                    setItems((items) => [...items, { label: "Some fourth label", link: "/some-fourth-link" }]);
+                }}
+            >
+                Add Block
+            </button>
+        </div>
+    );
+};
 
 describe("Breadcrumb component", () => {
     it("should render single item as current", () => {
@@ -59,5 +78,13 @@ describe("Breadcrumb component", () => {
         cy.get("@secondItem").realPress("Tab");
         cy.get(BREADCRUMB_ITEM_ID).last().find("button").type("{enter}");
         cy.get("@onClickStub").should("be.calledOnce");
+    });
+
+    it("should be able to handle a changing number of items", () => {
+        mount(<ChangingBreadcrumbs items={BREADCRUMB_ITEMS} />);
+
+        cy.get(BREADCRUMB_ITEM_ID).should("have.length", 3);
+        cy.get('[data-test-id="add-item-button"]').first().click();
+        cy.get(BREADCRUMB_ITEM_ID).should("have.length", 4);
     });
 });

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -2,8 +2,8 @@
 
 import { BadgeProps } from "@components/Badge/Badge";
 import { IconProps } from "@foundation/Icon/IconProps";
-import { useBreadcrumbItem, useBreadcrumbs } from "@react-aria/breadcrumbs";
-import React, { FC, MouseEvent, ReactElement, useRef } from "react";
+import { useBreadcrumbs } from "@react-aria/breadcrumbs";
+import React, { FC, MouseEvent, ReactElement } from "react";
 import { BreadcrumbItem } from "./BreadcrumbItem";
 import { CurrentBreadcrumbItem } from "./CurrentBreadcrumbItem";
 
@@ -38,22 +38,11 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({ items }) => {
                 {items.map(({ label, badges, bold, decorator, link, onClick }, index) => {
                     const isCurrent = index === items.length - 1;
                     const key = `breadcrumb-${index}`;
-                    const ref = useRef<HTMLAnchorElement | HTMLButtonElement | HTMLSpanElement | null>(null);
-                    const { itemProps } = useBreadcrumbItem(
-                        {
-                            isCurrent,
-                            children: label,
-                            elementType: link ? "a" : onClick ? "button" : "span",
-                        },
-                        ref,
-                    );
 
                     if (isCurrent) {
                         return (
                             <CurrentBreadcrumbItem
                                 key={key}
-                                ref={ref}
-                                ariaProps={itemProps}
                                 label={label}
                                 badges={badges}
                                 bold={bold}
@@ -67,8 +56,6 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({ items }) => {
                     return (
                         <BreadcrumbItem
                             key={key}
-                            ref={ref}
-                            ariaProps={itemProps}
                             label={label}
                             link={link}
                             onClick={onClick}

--- a/src/components/Breadcrumbs/CurrentBreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/CurrentBreadcrumbItem.tsx
@@ -1,9 +1,10 @@
 import { Badge, BadgeProps } from "@components/Badge/Badge";
+import { useBreadcrumbItem } from "@react-aria/breadcrumbs";
 import { useFocusRing } from "@react-aria/focus";
 import { mergeProps } from "@react-aria/utils";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
 import { merge } from "@utilities/merge";
-import React, { FC, forwardRef, HTMLAttributes, RefObject } from "react";
+import React, { FC, RefObject, useRef } from "react";
 import { Breadcrumb } from "./Breadcrumbs";
 
 const ItemWithBadges: FC<{ badges?: BadgeProps[] }> = ({ badges, children }) => (
@@ -18,17 +19,29 @@ const ItemWithBadges: FC<{ badges?: BadgeProps[] }> = ({ badges, children }) => 
     </span>
 );
 
-type CurrentBreadcrumbItemProps = Breadcrumb & {
-    ariaProps: HTMLAttributes<HTMLElement>;
-};
+type CurrentBreadcrumbItemProps = Breadcrumb;
 
-export const CurrentBreadcrumbItem = forwardRef<
-    HTMLAnchorElement | HTMLButtonElement | HTMLSpanElement | null,
-    CurrentBreadcrumbItemProps
->(({ label, badges, bold, decorator, link, onClick, ariaProps }, ref) => {
+export const CurrentBreadcrumbItem: FC<CurrentBreadcrumbItemProps> = ({
+    label,
+    badges,
+    bold,
+    decorator,
+    link,
+    onClick,
+}) => {
+    const ref = useRef<HTMLAnchorElement | HTMLButtonElement | HTMLSpanElement | null>(null);
+    const { itemProps } = useBreadcrumbItem(
+        {
+            isCurrent: true,
+            children: label,
+            elementType: link ? "a" : onClick ? "button" : "span",
+        },
+        ref,
+    );
+
     const classNames = merge([decorator && "tw-flex tw-gap-x-1 tw-items-center", bold && "tw-font-bold"]);
     const { isFocusVisible, focusProps } = useFocusRing();
-    const props = mergeProps(ariaProps, focusProps);
+    const props = mergeProps(itemProps, focusProps);
 
     return (
         <li
@@ -75,6 +88,4 @@ export const CurrentBreadcrumbItem = forwardRef<
             )}
         </li>
     );
-});
-
-CurrentBreadcrumbItem.displayName = "CurrentBreadcrumbItem";
+};


### PR DESCRIPTION
Fixes #645 