### PR TITLE
feat(TextInput): add copyable prop

### DIFF
--- a/src/components/TextInput/TextInput.spec.tsx
+++ b/src/components/TextInput/TextInput.spec.tsx
@@ -11,6 +11,7 @@ const INPUT_TEXT = "Hello test";
 const PLACEHOLDER = "placeholder";
 const PASSWORD = "SECRET password";
 const CLEAR_ICON_ID = "[data-test-id=clear-icon]";
+const COPY_ICON_ID = "[data-test-id=copy-icon]";
 const DECORATOR_ID = "[data-test-id=decorator]";
 const VISIBILITY_ICON_ID = "[data-test-id=visibility-icon]";
 
@@ -137,5 +138,22 @@ describe("Text Input component", () => {
     it("has the autoComplete turned off by default", () => {
         mount(<StatefulInput />);
         cy.get(TEXT_INPUT_ID).should("have.attr", "autoComplete", "off");
+    });
+
+    it("calls the copy event", () => {
+        mount(<StatefulInput copyable={true} value={INPUT_TEXT} />);
+        cy.get(COPY_ICON_ID).find("svg").should("have.attr", "name", "IconCopyToClipboard");
+        cy.get(COPY_ICON_ID).realClick();
+        cy.window().then((win) => {
+            win.navigator.clipboard.readText().then((text) => {
+                expect(text).to.equal(INPUT_TEXT);
+            });
+        });
+        cy.get(COPY_ICON_ID).find("svg").should("have.attr", "name", "IconCheck");
+    });
+
+    it("has the copy turned off by default", () => {
+        mount(<StatefulInput />);
+        cy.get(COPY_ICON_ID).should("not.exist");
     });
 });

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -19,7 +19,7 @@ export default {
         type: TextInputType.Text,
         validation: Validation.Default,
         spellcheck: true,
-        copyable: true,
+        copyable: false,
     },
     argTypes: {
         validation: {

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -19,6 +19,7 @@ export default {
         type: TextInputType.Text,
         validation: Validation.Default,
         spellcheck: true,
+        copyable: true,
     },
     argTypes: {
         validation: {

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -5,7 +5,7 @@ import IconView from "@foundation/Icon/Generated/IconView";
 import IconViewSlash from "@foundation/Icon/Generated/IconViewSlash";
 import IconCopyToClipboard from "@foundation/Icon/Generated/IconCopyToClipboard";
 import IconCheck from "@foundation/Icon/Generated/IconCheck";
-import IconRejectCircle from "@foundation/Icon/Generated/IconCheck";
+import IconRejectCircle from "@foundation/Icon/Generated/IconRejectCircle";
 import { useCopy } from "@hooks/useCopy";
 import { useMemoizedId } from "@hooks/useMemoizedId";
 import { useFocusRing } from "@react-aria/focus";

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -94,7 +94,7 @@ export const TextInput: FC<TextInputProps> = ({
     autocomplete = false,
     dotted = false,
     value = "",
-    copyable,
+    copyable = false,
     onChange,
     onEnterPressed,
     onBlur,
@@ -238,7 +238,7 @@ export const TextInput: FC<TextInputProps> = ({
                     ])}
                     onClick={() => copy(value)}
                     data-test-id="copy-icon"
-                    title="Copy input value"
+                    title="Copy input text"
                     disabled={disabled}
                     {...copyButtonFocusProps}
                 >

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -3,6 +3,10 @@
 import IconReject from "@foundation/Icon/Generated/IconReject";
 import IconView from "@foundation/Icon/Generated/IconView";
 import IconViewSlash from "@foundation/Icon/Generated/IconViewSlash";
+import IconCopyToClipboard from "@foundation/Icon/Generated/IconCopyToClipboard";
+import IconCheck from "@foundation/Icon/Generated/IconCheck";
+import IconRejectCircle from "@foundation/Icon/Generated/IconCheck";
+import { useCopy } from "@hooks/useCopy";
 import { useMemoizedId } from "@hooks/useMemoizedId";
 import { useFocusRing } from "@react-aria/focus";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
@@ -51,6 +55,7 @@ export type TextInputBaseProps = {
     disabled?: boolean;
     autocomplete?: boolean;
     validation?: Validation;
+    copyable?: boolean;
     value?: string;
     onChange?: (value: string) => void;
     onEnterPressed?: (event: KeyboardEvent<HTMLInputElement>) => void;
@@ -89,6 +94,7 @@ export const TextInput: FC<TextInputProps> = ({
     autocomplete = false,
     dotted = false,
     value = "",
+    copyable,
     onChange,
     onEnterPressed,
     onBlur,
@@ -99,6 +105,10 @@ export const TextInput: FC<TextInputProps> = ({
     const { isFocusVisible, focusProps } = useFocusRing({ within: true, isTextInput: true });
     const { isFocusVisible: clearButtonIsFocusVisible, focusProps: clearButtonFocusProps } = useFocusRing();
     const { isFocusVisible: passwordButtonIsFocusVisible, focusProps: passwordButtonFocusProps } = useFocusRing();
+    const { isFocusVisible: copyButtonIsFocusVisible, focusProps: copyButtonFocusProps } = useFocusRing();
+
+    const { copy, status } = useCopy();
+
     const inputElement = useRef<HTMLInputElement | null>(null);
     const [isObfuscated, setIsObfuscated] = useState(
         typeof obfuscated === "boolean" ? obfuscated : type === TextInputType.Password,
@@ -218,6 +228,32 @@ export const TextInput: FC<TextInputProps> = ({
                 <span className="tw-absolute tw-top-[-0.75rem] tw-right-[-0.75rem]">
                     <Spinner />
                 </span>
+            )}
+            {copyable && (
+                <button
+                    className={merge([
+                        "tw-flex tw-items-center tw-justify-center tw-transition-colors tw-rounded",
+                        disabled ? "tw-cursor-default tw-text-black-40" : "tw-text-black-60 hover:tw-text-black-100",
+                        copyButtonIsFocusVisible && FOCUS_STYLE,
+                    ])}
+                    onClick={() => copy(value)}
+                    data-test-id="copy-icon"
+                    title="Copy"
+                    disabled={disabled}
+                    {...copyButtonFocusProps}
+                >
+                    {status === "error" && (
+                        <span className="tw-text-box-negative-strong">
+                            <IconRejectCircle />
+                        </span>
+                    )}
+                    {status === "idle" && <IconCopyToClipboard />}
+                    {status === "success" && (
+                        <span className="tw-text-box-positive-strong">
+                            <IconCheck />
+                        </span>
+                    )}
+                </button>
             )}
         </div>
     );

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -238,7 +238,7 @@ export const TextInput: FC<TextInputProps> = ({
                     ])}
                     onClick={() => copy(value)}
                     data-test-id="copy-icon"
-                    title="Copy"
+                    title="Copy input value"
                     disabled={disabled}
                     {...copyButtonFocusProps}
                 >

--- a/src/hooks/useCopy.ts
+++ b/src/hooks/useCopy.ts
@@ -1,0 +1,32 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { useCallback, useEffect, useState } from "react";
+
+export const useCopy = (resetAfterMS = 2000) => {
+    const [status, setStatus] = useState<"success" | "error" | "idle">("idle");
+
+    const copy = useCallback(async (text: string) => {
+        setStatus("idle");
+        try {
+            await navigator.clipboard.writeText(text);
+            setStatus("success");
+        } catch {
+            setStatus("error");
+        }
+    }, []);
+
+    useEffect(() => {
+        let timeout: ReturnType<typeof setTimeout>;
+
+        if (resetAfterMS && (status === "success" || status === "error")) {
+            timeout = setTimeout(() => setStatus("idle"), resetAfterMS);
+        }
+        return () => {
+            if (resetAfterMS && (status === "success" || status === "error")) {
+                clearTimeout(timeout);
+            }
+        };
+    }, [status, resetAfterMS]);
+
+    return { copy, status };
+};


### PR DESCRIPTION
Add a new property to the TextInput component to allow for copying the value of the input. 
Adds a new "useCopy" hook