### PR TITLE
feat(Textarea)!: add value prop and remove children

### DIFF
--- a/src/components/Textarea/Textarea.spec.tsx
+++ b/src/components/Textarea/Textarea.spec.tsx
@@ -12,7 +12,7 @@ const INPUT_TEXT = "some text";
 
 describe("Textarea component", () => {
     it("renders", () => {
-        mount(<Textarea>{DEFAULT_TEXT}</Textarea>);
+        mount(<Textarea></Textarea>);
         cy.get("textarea").as("textarea");
         cy.get("@textarea").should("not.have.attr", "value");
         cy.get("@textarea").should("not.have.attr", "required");

--- a/src/components/Textarea/Textarea.spec.tsx
+++ b/src/components/Textarea/Textarea.spec.tsx
@@ -14,11 +14,16 @@ describe("Textarea component", () => {
     it("renders", () => {
         mount(<Textarea>{DEFAULT_TEXT}</Textarea>);
         cy.get("textarea").as("textarea");
-        cy.get("@textarea").contains(DEFAULT_TEXT);
+        cy.get("@textarea").should("not.have.attr", "value");
         cy.get("@textarea").should("not.have.attr", "required");
         cy.get("@textarea").should("not.have.attr", "placeholder");
         cy.get("@textarea").should("not.have.attr", "disabled");
         cy.get("@textarea").find('[data-test-id="decorator"]').should("have.length", 0);
+    });
+
+    it("sets and gets the value", () => {
+        mount(<Textarea value={DEFAULT_TEXT}></Textarea>);
+        cy.get("textarea").should("have.value", DEFAULT_TEXT);
     });
 
     it("has the required attribute", () => {

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Meta, Story } from "@storybook/react";
 import { Textarea as TextareaComponent, TextareaProps } from "./Textarea";
 import { Validation } from "@utilities/validation";
@@ -28,4 +28,9 @@ export default {
     },
 } as Meta<TextareaProps>;
 
-export const Textarea: Story<TextareaProps> = (args: TextareaProps) => <TextareaComponent {...args} />;
+export const Textarea: Story<TextareaProps> = (args: TextareaProps) => {
+    const [input, setInput] = useState("");
+    useEffect(() => setInput(`${args.value || ""}`), [args.value]);
+
+    return <TextareaComponent {...args} value={input} onInput={setInput} />;
+};

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -15,6 +15,7 @@ export default {
         validation: Validation.Default,
     },
     argTypes: {
+        value: { type: "string" },
         placeholder: { type: "string" },
         decorator: { type: "string" },
         onInput: { action: "onInput" },

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -5,12 +5,13 @@ import { useFocusRing } from "@react-aria/focus";
 import { mergeProps } from "@react-aria/utils";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
 import { merge } from "@utilities/merge";
-import React, { FC, FocusEvent, FormEvent, PropsWithChildren, ReactNode } from "react";
 import { Validation, validationClassMap } from "@utilities/validation";
 import { LoadingCircle, LoadingCircleSize } from "@components/LoadingCircle";
+import React, { FC, FocusEvent, FormEvent, ReactNode } from "react";
 
-export type TextareaProps = PropsWithChildren<{
+export type TextareaProps = {
     id?: string;
+    value?: string;
     required?: boolean;
     decorator?: ReactNode;
     placeholder?: string;
@@ -18,11 +19,11 @@ export type TextareaProps = PropsWithChildren<{
     onInput?: (value: string) => void;
     onBlur?: (value: string) => void;
     validation?: Validation;
-}>;
+};
 
 export const Textarea: FC<TextareaProps> = ({
     id: propId,
-    children,
+    value,
     required = false,
     decorator,
     placeholder,
@@ -47,9 +48,10 @@ export const Textarea: FC<TextareaProps> = ({
                 {...mergeProps(focusProps, {
                     onBlur: (event: FocusEvent<HTMLTextAreaElement>) => onBlur && onBlur(event.target.value),
                     onInput: (event: FormEvent<HTMLTextAreaElement>) =>
-                        onInput && onInput((event.target as HTMLTextAreaElement).value),
+                        onInput && onInput((event.currentTarget as HTMLTextAreaElement).value),
                 })}
                 id={useMemoizedId(propId)}
+                value={value}
                 placeholder={placeholder}
                 required={required}
                 className={merge([
@@ -62,9 +64,7 @@ export const Textarea: FC<TextareaProps> = ({
                     validationClassMap[validation],
                 ])}
                 disabled={disabled}
-            >
-                {children}
-            </textarea>
+            ></textarea>
             {validation === Validation.Loading && (
                 <span className="tw-absolute tw-top-[-0.55rem] tw-right-[-0.55rem] tw-bg-white tw-rounded-full tw-p-[2px] tw-border tw-border-black-10">
                     <LoadingCircle size={LoadingCircleSize.ExtraSmall} />

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -48,7 +48,7 @@ export const Textarea: FC<TextareaProps> = ({
                 {...mergeProps(focusProps, {
                     onBlur: (event: FocusEvent<HTMLTextAreaElement>) => onBlur && onBlur(event.target.value),
                     onInput: (event: FormEvent<HTMLTextAreaElement>) =>
-                        onInput && onInput((event.currentTarget as HTMLTextAreaElement).value),
+                        onInput && onInput((event.target as HTMLTextAreaElement).value),
                 })}
                 id={useMemoizedId(propId)}
                 value={value}


### PR DESCRIPTION
Removing the `children` from the `<Textarea>` component and adding `value` prop instead, as discussed here: 
https://frontify.slack.com/archives/C02PSJTPA3D/p1646391887846429