### PR TITLE
Revert "fix(breadcrumbs): Remove unnecessary tabIndex when no link"

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -39,10 +39,6 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({ items }) => {
                     const isCurrent = index === items.length - 1;
                     const key = `breadcrumb-${index}`;
 
-                    if (!link && !onClick) {
-                        delete itemProps["tabIndex"];
-                    }
-
                     if (isCurrent) {
                         return (
                             <CurrentBreadcrumbItem


### PR DESCRIPTION
Reverts Frontify/arcade#648