### PR TITLE
feat(ColorPicker): refactor ColorPicker to use react-colorful

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
                 "@xstate/react": "^1.6.3",
                 "date-fns": "^2.28.0",
                 "framer-motion": "^6.2.1",
-                "react-color": "^2.19.3",
                 "react-colorful": "^5.5.1",
                 "react-datepicker": "^4.6.0",
                 "react-dnd": "^15.1.1",
@@ -2557,14 +2556,6 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
-        },
-        "node_modules/@icons/material": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-            "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-            "peerDependencies": {
-                "react": "*"
-            }
         },
         "node_modules/@internationalized/date": {
             "version": "3.0.0-alpha.1",
@@ -17744,11 +17735,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "node_modules/lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-        },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -18006,11 +17992,6 @@
             "peerDependencies": {
                 "react": ">= 0.14.0"
             }
-        },
-        "node_modules/material-colors": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-            "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
         },
         "node_modules/md5.js": {
             "version": "1.3.5",
@@ -20560,23 +20541,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-color": {
-            "version": "2.19.3",
-            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
-            "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-            "dependencies": {
-                "@icons/material": "^0.2.4",
-                "lodash": "^4.17.15",
-                "lodash-es": "^4.17.15",
-                "material-colors": "^1.2.1",
-                "prop-types": "^15.5.10",
-                "reactcss": "^1.2.0",
-                "tinycolor2": "^1.4.1"
-            },
-            "peerDependencies": {
-                "react": "*"
-            }
-        },
         "node_modules/react-colorful": {
             "version": "5.5.1",
             "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
@@ -20943,14 +20907,6 @@
             "peerDependencies": {
                 "react": "^16.8.0  || ^17.0.0",
                 "react-dom": "^16.8.0  || ^17.0.0"
-            }
-        },
-        "node_modules/reactcss": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-            "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-            "dependencies": {
-                "lodash": "^4.0.1"
             }
         },
         "node_modules/read-cache": {
@@ -28618,12 +28574,6 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
-        },
-        "@icons/material": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-            "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-            "requires": {}
         },
         "@internationalized/date": {
             "version": "3.0.0-alpha.1",
@@ -39907,11 +39857,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-        },
         "lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -40111,11 +40056,6 @@
             "integrity": "sha512-YQEMMMCX3PYOWtUAQu8Fmz5/sH09s17eyQnDubwaAo8sWmnRTT1og96EFv1vL59l4nWfmtF3L91pqkuheVqRlA==",
             "dev": true,
             "requires": {}
-        },
-        "material-colors": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-            "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
         },
         "md5.js": {
             "version": "1.3.5",
@@ -42101,20 +42041,6 @@
                 "object-assign": "^4.1.1"
             }
         },
-        "react-color": {
-            "version": "2.19.3",
-            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
-            "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-            "requires": {
-                "@icons/material": "^0.2.4",
-                "lodash": "^4.17.15",
-                "lodash-es": "^4.17.15",
-                "material-colors": "^1.2.1",
-                "prop-types": "^15.5.10",
-                "reactcss": "^1.2.0",
-                "tinycolor2": "^1.4.1"
-            }
-        },
         "react-colorful": {
             "version": "5.5.1",
             "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
@@ -42393,14 +42319,6 @@
                 "throttle-debounce": "^3.0.1",
                 "ts-easing": "^0.2.0",
                 "tslib": "^2.1.0"
-            }
-        },
-        "reactcss": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-            "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-            "requires": {
-                "lodash": "^4.0.1"
             }
         },
         "read-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
                 "date-fns": "^2.28.0",
                 "framer-motion": "^6.2.1",
                 "react-color": "^2.19.3",
+                "react-colorful": "^5.5.1",
                 "react-datepicker": "^4.6.0",
                 "react-dnd": "^15.1.1",
                 "react-dnd-html5-backend": "^15.1.2",
@@ -20580,7 +20581,6 @@
             "version": "5.5.1",
             "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
             "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-            "dev": true,
             "peerDependencies": {
                 "react": ">=16.8.0",
                 "react-dom": ">=16.8.0"
@@ -42119,7 +42119,6 @@
             "version": "5.5.1",
             "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
             "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-            "dev": true,
             "requires": {}
         },
         "react-datepicker": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
         "date-fns": "^2.28.0",
         "framer-motion": "^6.2.1",
         "react-color": "^2.19.3",
+        "react-colorful": "^5.5.1",
         "react-datepicker": "^4.6.0",
         "react-dnd": "^15.1.1",
         "react-dnd-html5-backend": "^15.1.2",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
         "@xstate/react": "^1.6.3",
         "date-fns": "^2.28.0",
         "framer-motion": "^6.2.1",
-        "react-color": "^2.19.3",
         "react-colorful": "^5.5.1",
         "react-datepicker": "^4.6.0",
         "react-dnd": "^15.1.1",

--- a/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
+++ b/src/components/ColorInputFlyout/ColorPickerTrigger.tsx
@@ -57,7 +57,7 @@ export const ColorInputTrigger: FC<ColorInputTriggerProps> = ({
                         currentColor ? (
                             <span
                                 className={merge([
-                                    "tw-h-4 tw-w-4 tw-rounded tw-flex tw-items-center tw-justify-center",
+                                    "tw-h-4 tw-w-4 tw-rounded tw-flex tw-items-center tw-justify-center tw-ring-1 tw-ring-black-10 tw-ring-offset-1",
                                     disabled && "tw-opacity-50",
                                 ])}
                                 style={{ backgroundColor }}

--- a/src/components/ColorPicker/BrandColorPicker.tsx
+++ b/src/components/ColorPicker/BrandColorPicker.tsx
@@ -85,13 +85,10 @@ export const BrandColorPicker: FC<Props> = ({ palettes: defaultPalettes = [], cu
                               >
                                   {colors.map((color) => (
                                       <li key={color.name} data-test-id="brand-color">
-                                          <button
-                                              className="tw-flex tw-overflow-hidden tw-w-full"
-                                              onClick={() => onSelect(color)}
-                                          >
+                                          <button className="tw-flex tw-w-full" onClick={() => onSelect(color)}>
                                               <span
                                                   className={merge([
-                                                      "tw-h-8 tw-w-8 tw-mr-2 tw-rounded tw-flex tw-items-center tw-justify-center ",
+                                                      "tw-h-8 tw-w-8 tw-mr-2 tw-rounded tw-flex tw-items-center tw-justify-center tw-ring-1 tw-ring-black-10 tw-ring-offset-1",
                                                       isColorLight(color) ? "tw-text-black" : "tw-text-white",
                                                   ])}
                                                   style={{ background: tinycolor(color).toRgbString() }}

--- a/src/components/ColorPicker/ColorInput.tsx
+++ b/src/components/ColorPicker/ColorInput.tsx
@@ -42,7 +42,7 @@ export const ColorInput: FC<ColorInputProps> = ({
         <div
             {...focusProps}
             className={merge([
-                "tw-flex tw-items-center tw-h-9 tw-px-3 tw-border tw-rounded tw-text-s tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent focus-within:tw-border-black-90 tw-border-black-20",
+                "tw-flex tw-items-center tw-h-9 tw-px-2 tw-border tw-rounded tw-text-s tw-font-sans tw-relative tw-bg-white dark:tw-bg-transparent focus-within:tw-border-black-90 tw-border-black-20",
                 isFocusVisible && FOCUS_STYLE,
             ])}
             data-test-id="color-input"

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -1,13 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Slider } from "@components/Slider/Slider";
-import { getColorDisplayValue, isColorLight } from "@utilities/colors";
-import { merge } from "@utilities/merge";
-import React, { FC, useEffect, useState } from "react";
-import tinycolor from "tinycolor2";
+import React, { FC, useState } from "react";
 import { Color, ColorFormat, Palette } from "../../types/colors";
 import { BrandColorPicker } from "./BrandColorPicker";
+import { ColorPreview } from "./ColorPreview";
 import { CustomColorPicker } from "./CustomColorPicker";
+import "./styles.css";
 
 export type ColorPickerProps = {
     palettes?: Palette[];
@@ -37,16 +36,11 @@ export const ColorPicker: FC<ColorPickerProps> = ({
     currentFormat = ColorFormat.Hex,
 }) => {
     const [colorType, setColorType] = useState(ColorType.Brand);
-    const [color, setColor] = useState<Color>(currentColor);
-
-    useEffect(() => {
-        setColor({ ...currentColor, a: currentColor.a || 1 });
-    }, [currentColor]);
 
     return (
         <div className="tw-w-[400px] tw-relative">
-            {showPreview && <ColorPreview color={color} format={currentFormat} />}
-            <div className="tw-p-6 tw-flex tw-flex-col tw-gap-5">
+            {showPreview && <ColorPreview color={currentColor} format={currentFormat} />}
+            <div className="tw-p-5 tw-flex tw-flex-col tw-gap-5">
                 {palettes && (
                     <Slider
                         items={colorTypes}
@@ -55,37 +49,15 @@ export const ColorPicker: FC<ColorPickerProps> = ({
                     />
                 )}
                 {palettes && colorType === ColorType.Brand ? (
-                    <BrandColorPicker currentColor={color} palettes={palettes} onSelect={onSelect} />
+                    <BrandColorPicker currentColor={currentColor} palettes={palettes} onSelect={onSelect} />
                 ) : (
                     <CustomColorPicker
-                        currentColor={color}
+                        currentColor={currentColor}
                         currentFormat={currentFormat}
                         setFormat={setFormat}
                         onSelect={onSelect}
                     />
                 )}
-            </div>
-        </div>
-    );
-};
-
-export const ColorPreview: FC<{ color: Color; format: ColorFormat }> = ({ color, format }) => {
-    const parsedColor = tinycolor(color);
-    const backgroundColor = parsedColor.toRgbString();
-    const colorName = color.name;
-    const displayValue = getColorDisplayValue(color, format);
-    return (
-        <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">
-            <div
-                className={merge([
-                    "tw-flex tw-justify-center tw-p-7 tw-text-m tw-gap-2",
-                    isColorLight(color) ? "tw-text-black" : "tw-text-white",
-                ])}
-                style={{ backgroundColor }}
-                data-test-id="color-preview"
-            >
-                {colorName && <span className="tw-font-bold">{colorName}</span>}
-                <span className={colorName ? "" : "tw-font-bold"}>{displayValue}</span>
             </div>
         </div>
     );

--- a/src/components/ColorPicker/ColorPreview.tsx
+++ b/src/components/ColorPicker/ColorPreview.tsx
@@ -18,7 +18,7 @@ export const ColorPreview: FC<ColorPreviewProps> = ({ color, format }) => {
     const displayValue = getColorDisplayValue(color, format);
 
     return (
-        <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">
+        <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95 tw-border-b tw-border-b-black-10">
             <div
                 className={merge([
                     "tw-flex tw-justify-center tw-p-7 tw-text-m tw-gap-2",

--- a/src/components/ColorPicker/ColorPreview.tsx
+++ b/src/components/ColorPicker/ColorPreview.tsx
@@ -1,0 +1,35 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { getColorDisplayValue, isColorLight } from "@utilities/colors";
+import { merge } from "@utilities/merge";
+import React, { FC } from "react";
+import tinycolor from "tinycolor2";
+import { Color, ColorFormat } from "../../types/colors";
+
+type ColorPreviewProps = {
+    color: Color;
+    format: ColorFormat;
+};
+
+export const ColorPreview: FC<ColorPreviewProps> = ({ color, format }) => {
+    const parsedColor = tinycolor(color);
+    const backgroundColor = parsedColor.toRgbString();
+    const colorName = color.name;
+    const displayValue = getColorDisplayValue(color, format);
+
+    return (
+        <div className="tw-sticky tw-top-0 tw-bg-white tw-z-20 dark:tw-bg-black-95">
+            <div
+                className={merge([
+                    "tw-flex tw-justify-center tw-p-7 tw-text-m tw-gap-2",
+                    isColorLight(color) ? "tw-text-black" : "tw-text-white",
+                ])}
+                style={{ backgroundColor }}
+                data-test-id="color-preview"
+            >
+                {colorName && <span className="tw-font-bold">{colorName}</span>}
+                <span className={colorName ? "" : "tw-font-bold"}>{displayValue}</span>
+            </div>
+        </div>
+    );
+};

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -4,24 +4,14 @@
 
 import { Dropdown } from "@components/Dropdown/Dropdown";
 import { TextInputType } from "@components/TextInput/TextInput";
-import { debounce } from "@utilities/debounce";
-import { merge } from "@utilities/merge";
 import React, { FC, useEffect, useState } from "react";
-// @ts-ignore
-import { Alpha, Hue, Saturation } from "react-color/lib/components/common";
+import { HexColorPicker, RgbaColorPicker } from "react-colorful";
 import tinycolor from "tinycolor2";
 import { Color, ColorFormat } from "../../types/colors";
 import { ColorInput, DecoratorPosition } from "./ColorInput";
 import { ColorPickerProps } from "./ColorPicker";
 
-const ColorPointer: FC<{ offset?: boolean }> = ({ offset = true }) => (
-    <div
-        className={merge([
-            "tw-w-4 tw-h-4 tw-rounded-full tw-border-2 tw-border-white tw--translate-y-2",
-            offset && "tw--translate-x-2",
-        ])}
-    />
-);
+const convertToHex = (color: Color) => tinycolor(color).toHex();
 
 export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
     currentColor,
@@ -29,18 +19,17 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
     setFormat,
     onSelect,
 }) => {
-    const colorFormats = Object.values(ColorFormat).map((id) => ({ id, title: id.toLocaleUpperCase() }));
-    const [color, setColor] = useState<Color>(currentColor);
-    const parsedColor = tinycolor(color);
-    const rgb = parsedColor.toRgb();
-    const hsl = parsedColor.toHsl();
-    const hsv = parsedColor.toHsv();
-    const { r, g, b, a } = rgb;
-    const [hexInput, setHexInput] = useState(parsedColor.toHex());
+    const formatMenuBlock = [
+        {
+            id: "color-picker-format-dropdown-block",
+            menuItems: Object.values(ColorFormat).map((id) => ({ id, title: id.toLocaleUpperCase() })),
+        },
+    ];
+    const { r, g, b, a = 1 } = currentColor;
+    const [hexInput, setHexInput] = useState(convertToHex(currentColor));
+    const [alpha, setAlpha] = useState(a);
 
-    useEffect(() => {
-        setColor(currentColor);
-    }, [currentColor]);
+    const onHexColorChange = (color: string) => onSelect({ ...tinycolor(color).toRgb(), a: alpha });
 
     const handleHexChange = () => {
         const parsedHex = tinycolor(hexInput);
@@ -50,55 +39,25 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
     };
 
     useEffect(() => {
-        setHexInput(parsedColor.toHex());
-    }, [color]);
+        setAlpha(a);
+        setHexInput(convertToHex(currentColor));
+    }, [currentColor]);
 
     return (
-        <div className="tw-flex tw-flex-col tw-gap-5" data-test-id="custom-color-picker">
+        <div className="tw-flex tw-flex-col tw-gap-5" data-test-id="custom-color-picker" id="custom-color-picker">
             <div className="tw-flex tw-gap-2 tw-w-full tw-h-[200px]">
                 <div className="tw-relative tw-grow tw-overflow-hidden tw-rounded">
-                    <Saturation
-                        rgb={rgb}
-                        hsl={hsl}
-                        hsv={hsv}
-                        pointer={() => <ColorPointer />}
-                        onChange={debounce((color) => onSelect(tinycolor(color).toRgb()))}
-                    />
-                </div>
-                <div className="tw-relative tw-w-6 tw-overflow-hidden tw-rounded">
-                    <Hue
-                        pointer={() => (
-                            <div className="tw-w-6 tw-flex tw-justify-center">
-                                <ColorPointer offset={false} />
-                            </div>
-                        )}
-                        rgb={rgb}
-                        hsl={hsl}
-                        hsv={hsv}
-                        direction="vertical"
-                        onChange={debounce((color) => onSelect(tinycolor(color).toRgb()))}
-                    />
-                </div>
-                <div className="tw-relative tw-w-6 tw-overflow-hidden tw-rounded">
-                    <Alpha
-                        rgb={rgb}
-                        hsl={hsl}
-                        hsv={hsv}
-                        direction="vertical"
-                        pointer={() => (
-                            <div className="tw-w-[18px] tw-flex tw-justify-center">
-                                <ColorPointer offset={false} />
-                            </div>
-                        )}
-                        style={{ pointer: { top: `${a * 100}%` } }}
-                        onChange={debounce((color) => onSelect(tinycolor(color).toRgb()))}
-                    />
+                    {currentFormat === ColorFormat.Rgba ? (
+                        <RgbaColorPicker color={{ ...currentColor, a }} onChange={onSelect} />
+                    ) : (
+                        <HexColorPicker color={hexInput} onChange={onHexColorChange} />
+                    )}
                 </div>
             </div>
             <div className="tw-flex tw-flex-col md:tw-flex-row tw-gap-2 tw-max-w-full">
-                <div className="tw-min-w-[100px]">
+                <div className="tw-min-w-[84px]">
                     <Dropdown
-                        menuBlocks={[{ id: "color-picker-format-dropdown-block", menuItems: colorFormats }]}
+                        menuBlocks={formatMenuBlock}
                         activeItemId={currentFormat}
                         onChange={(id) => id && setFormat && setFormat(id as ColorFormat)}
                     />
@@ -123,7 +82,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             type={TextInputType.Number}
                             value={r.toString()}
                             decorator="R"
-                            onChange={(r) => onSelect({ ...color, r: parseInt(r) })}
+                            onChange={(r) => onSelect({ ...currentColor, r: parseInt(r) })}
                         />
                         <ColorInput
                             min={0}
@@ -132,7 +91,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             type={TextInputType.Number}
                             value={g.toString()}
                             decorator="G"
-                            onChange={(g) => onSelect({ ...color, g: parseInt(g) })}
+                            onChange={(g) => onSelect({ ...currentColor, g: parseInt(g) })}
                         />
                         <ColorInput
                             min={0}
@@ -141,7 +100,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                             type={TextInputType.Number}
                             value={b.toString()}
                             decorator="B"
-                            onChange={(b) => onSelect({ ...color, b: parseInt(b) })}
+                            onChange={(b) => onSelect({ ...currentColor, b: parseInt(b) })}
                         />
                     </>
                 )}
@@ -150,12 +109,13 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                     max={100}
                     size={3}
                     type={TextInputType.Number}
-                    value={Math.trunc(a * 100).toString()}
+                    value={Math.trunc(alpha * 100).toString()}
                     decorator="%"
                     decoratorPosition={DecoratorPosition.Right}
                     onChange={(value) => {
                         const a = parseInt(value || "0", 10) / 100;
-                        onSelect({ ...color, a });
+                        setAlpha(a);
+                        onSelect({ ...currentColor, a });
                     }}
                 />
             </div>

--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -1,11 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// Since there are no correct typings atm we need to ignore these imports
 
 import { Dropdown } from "@components/Dropdown/Dropdown";
 import { TextInputType } from "@components/TextInput/TextInput";
 import React, { FC, useEffect, useState } from "react";
-import { HexColorPicker, RgbaColorPicker } from "react-colorful";
+import { RgbaColorPicker } from "react-colorful";
 import tinycolor from "tinycolor2";
 import { Color, ColorFormat } from "../../types/colors";
 import { ColorInput, DecoratorPosition } from "./ColorInput";
@@ -29,8 +27,6 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
     const [hexInput, setHexInput] = useState(convertToHex(currentColor));
     const [alpha, setAlpha] = useState(a);
 
-    const onHexColorChange = (color: string) => onSelect({ ...tinycolor(color).toRgb(), a: alpha });
-
     const handleHexChange = () => {
         const parsedHex = tinycolor(hexInput);
         if (parsedHex.isValid()) {
@@ -47,11 +43,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
         <div className="tw-flex tw-flex-col tw-gap-5" data-test-id="custom-color-picker" id="custom-color-picker">
             <div className="tw-flex tw-gap-2 tw-w-full tw-h-[200px]">
                 <div className="tw-relative tw-grow tw-overflow-hidden tw-rounded">
-                    {currentFormat === ColorFormat.Rgba ? (
-                        <RgbaColorPicker color={{ ...currentColor, a }} onChange={onSelect} />
-                    ) : (
-                        <HexColorPicker color={hexInput} onChange={onHexColorChange} />
-                    )}
+                    <RgbaColorPicker color={{ ...currentColor, a }} onChange={onSelect} />
                 </div>
             </div>
             <div className="tw-flex tw-flex-col md:tw-flex-row tw-gap-2 tw-max-w-full">

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -1,4 +1,5 @@
 export * from "./BrandColorPicker";
 export * from "./ColorInput";
 export * from "./ColorPicker";
+export * from "./ColorPreview";
 export * from "./CustomColorPicker";

--- a/src/components/ColorPicker/styles.css
+++ b/src/components/ColorPicker/styles.css
@@ -1,0 +1,3 @@
+#custom-color-picker .react-colorful {
+    width: 100%;
+}


### PR DESCRIPTION
This PR changes the ColorPicker to use `react-colorful` library.

It also adds a border to the dropdown swatch, list swatches, and on the bottom edge of the color preview.