### PR TITLE
fix(rte): export empty value

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -8,7 +8,7 @@ import { EditableProps } from "slate-react/dist/components/editable";
 import { Toolbar } from "./Toolbar";
 import { getEditorConfig } from "./utils/getEditorConfig";
 import { TextStyleType } from "./utils/getTextStyles";
-import { EMPTY_VALUE, parseRawValue } from "./utils/parseRawValue";
+import { EMPTY_RICH_TEXT_VALUE, parseRawValue } from "./utils/parseRawValue";
 
 export type RichTextEditorProps = {
     id?: string;
@@ -52,8 +52,8 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
             const point = { path: [0, 0], offset: 0 };
             editor.selection = { anchor: point, focus: point };
             editor.history = { redos: [], undos: [] };
-            editor.children = EMPTY_VALUE;
-            localValue.current = EMPTY_VALUE;
+            editor.children = EMPTY_RICH_TEXT_VALUE;
+            localValue.current = EMPTY_RICH_TEXT_VALUE;
         }
     }, [clear]);
 

--- a/src/components/RichTextEditor/index.ts
+++ b/src/components/RichTextEditor/index.ts
@@ -1,3 +1,4 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export * from "./RichTextEditor";
+export { EMPTY_RICH_TEXT_VALUE } from "./utils/parseRawValue";

--- a/src/components/RichTextEditor/utils/parseRawValue.ts
+++ b/src/components/RichTextEditor/utils/parseRawValue.ts
@@ -3,10 +3,10 @@
 import { createPlateEditor, deserializeHtml, ELEMENT_PARAGRAPH, parseHtmlDocument, TDescendant } from "@udecode/plate";
 import { getEditorConfig } from "./getEditorConfig";
 
-export const EMPTY_VALUE: TDescendant[] = [{ type: ELEMENT_PARAGRAPH, children: [{ text: "" }] }];
+export const EMPTY_RICH_TEXT_VALUE: TDescendant[] = [{ type: ELEMENT_PARAGRAPH, children: [{ text: "" }] }];
 
 export const parseRawValue = (raw?: string): TDescendant[] => {
-    let parsedValue = EMPTY_VALUE;
+    let parsedValue = EMPTY_RICH_TEXT_VALUE;
 
     if (!raw) {
         return parsedValue;


### PR DESCRIPTION
Export the specified value of the empty rich text editor for use within clarify to implement the suggestion made here https://github.com/Frontify/clarify/pull/8165#discussion_r832395314