### PR TITLE
fix(modal): remove fixed max height

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -58,11 +58,11 @@ const ModalComponent: FC<ModalProps> = memo((props) => {
             style={{ background: "rgba(0, 0, 0, .5)" }}
             onPointerDown={onPointerDown}
             data-is-underlay={true}
-            className="tw-fixed tw-top-0 tw-left-0 tw-bottom-0 tw-right-0 tw-z-50 tw-flex tw-justify-center tw-items-center tw-p-3"
+            className="tw-fixed tw-top-0 tw-left-0 tw-bottom-0 tw-right-0 tw-z-50 tw-flex tw-justify-center tw-items-center tw-p-4"
         >
             {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
             <FocusScope contain restoreFocus autoFocus>
-                <motion.div variants={MODAL_VARIANTS} className="tw-w-full tw-max-w-[790px] tw-max-h-[600px] tw-h-full">
+                <motion.div variants={MODAL_VARIANTS} className="tw-w-full tw-max-w-[790px] tw-max-h-full">
                     <div
                         {...overlayProps}
                         {...dialogProps}


### PR DESCRIPTION
This pr changes the modal max height to be dependent on the screen height, rather than what it was originally (fixed max height of 600px)