### PR TITLE
fix(Slider): disable initial animation

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -130,6 +130,7 @@ export const Slider: FC<SliderProps> = ({
             <motion.div
                 aria-hidden="true"
                 animate={{ x: `${100 * selectedIndex}%` }}
+                initial={false}
                 transition={{ type: "tween", duration: 0.3 }}
                 style={{
                     width: `${100 / items.length}%`,


### PR DESCRIPTION
Disables initial animation on Slider (when other value than the one on the far left is preselected).