### PR TITLE
chore: remove renovate update grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:weekly", "group:allNonMajor"],
+  "extends": ["config:base", "schedule:weekly"],
   "labels": ["dependencies"],
   "vulnerabilityAlerts": {
     "labels": ["security"]


### PR DESCRIPTION
Removes the `allNonMajor` as it is harder to fix the big PR, it was enabled to avoid spam in #arcade-notifications but now the Renovate will check once a week instead of everyday before