### PR TITLE
fix(ColorPicker): remove overflow hidden from picker

### DIFF
--- a/src/components/ColorPicker/CustomColorPicker.tsx
+++ b/src/components/ColorPicker/CustomColorPicker.tsx
@@ -110,7 +110,7 @@ export const CustomColorPicker: FC<Omit<ColorPickerProps, "palette">> = ({
                 />
             </div>
             <div className="tw-flex tw-gap-2 tw-w-full tw-h-[200px]">
-                <div className="tw-relative tw-grow tw-overflow-hidden tw-rounded">
+                <div className="tw-relative tw-grow tw-rounded">
                     <RgbaColorPicker color={{ ...currentColor, a }} onChange={onSelect} style={{ width: "100%" }} />
                 </div>
             </div>


### PR DESCRIPTION
- Allows the 'handles' to appear even if they are right at the edge or corner of the color picker