### PR TITLE
chore: update storybook-builder-vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
                 "@storybook/addon-actions": "6.4.20",
                 "@storybook/addon-essentials": "6.4.20",
                 "@storybook/addon-links": "6.4.20",
-                "@storybook/builder-vite": "0.1.28",
+                "@storybook/builder-vite": "0.1.30",
                 "@storybook/react": "6.4.20",
                 "@svgr/core": "6.2.1",
                 "@svgr/plugin-jsx": "6.2.1",
@@ -6426,9 +6426,9 @@
             }
         },
         "node_modules/@storybook/builder-vite": {
-            "version": "0.1.28",
-            "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-0.1.28.tgz",
-            "integrity": "sha512-hVaviYlKt/KpIOYBnIlFCpAwALaEdj2inousF2t/1e5tIKMTqB6JHOqKd1Zfm+kDwENdwmXzJ2VI/L85Xj96XQ==",
+            "version": "0.1.30",
+            "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-0.1.30.tgz",
+            "integrity": "sha512-6Qf7IVZxEg3l18xXm0iqsGyG/T0ixeE8gU8zAo2u8wuEYCGNsQrnbu6it8BOXTJFk3gLPPETvxGszVIP56gRtA==",
             "dev": true,
             "dependencies": {
                 "@joshwooding/vite-plugin-react-docgen-typescript": "0.0.4",
@@ -35188,9 +35188,9 @@
             }
         },
         "@storybook/builder-vite": {
-            "version": "0.1.28",
-            "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-0.1.28.tgz",
-            "integrity": "sha512-hVaviYlKt/KpIOYBnIlFCpAwALaEdj2inousF2t/1e5tIKMTqB6JHOqKd1Zfm+kDwENdwmXzJ2VI/L85Xj96XQ==",
+            "version": "0.1.30",
+            "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-0.1.30.tgz",
+            "integrity": "sha512-6Qf7IVZxEg3l18xXm0iqsGyG/T0ixeE8gU8zAo2u8wuEYCGNsQrnbu6it8BOXTJFk3gLPPETvxGszVIP56gRtA==",
             "dev": true,
             "requires": {
                 "@joshwooding/vite-plugin-react-docgen-typescript": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@storybook/addon-actions": "6.4.20",
         "@storybook/addon-essentials": "6.4.20",
         "@storybook/addon-links": "6.4.20",
-        "@storybook/builder-vite": "0.1.28",
+        "@storybook/builder-vite": "0.1.30",
         "@storybook/react": "6.4.20",
         "@svgr/core": "6.2.1",
         "@svgr/plugin-jsx": "6.2.1",


### PR DESCRIPTION
Issue is fixed: https://github.com/storybookjs/builder-vite/pull/346
Flyout in storybook should work as intended with this version of the package.