### PR TITLE
fix(MultiSelect): add non-transparent background

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -2,7 +2,7 @@
 
 import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
-import { FormControl } from "..";
+import { FormControl } from "@components/FormControl";
 import { MultiSelect as MultiSelectComponent, MultiSelectProps, MultiSelectType } from "./MultiSelect";
 
 // eslint-disable-next-line import/no-default-export

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -43,6 +43,7 @@ export default {
 
 const MultiSelectTemplate: Story<MultiSelectProps> = (args) => {
     const [activeItemKeys, setActiveItemKeys] = useState<(string | number)[]>(args.activeItemKeys);
+
     return (
         <MultiSelectComponent
             {...args}
@@ -54,6 +55,7 @@ const MultiSelectTemplate: Story<MultiSelectProps> = (args) => {
 
 const MultiSelectFormControlTemplate: Story<MultiSelectProps> = (args) => {
     const [activeItemKeys, setActiveItemKeys] = useState<(string | number)[]>(args.activeItemKeys);
+
     return (
         <FormControl helper={{ text: "Helper Text" }} label={{ children: "Multi-Select", htmlFor: "" }}>
             <MultiSelectComponent

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -2,6 +2,7 @@
 
 import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
+import { FormControl } from "..";
 import { MultiSelect as MultiSelectComponent, MultiSelectProps, MultiSelectType } from "./MultiSelect";
 
 // eslint-disable-next-line import/no-default-export
@@ -51,6 +52,19 @@ const MultiSelectTemplate: Story<MultiSelectProps> = (args) => {
     );
 };
 
+const MultiSelectFormControlTemplate: Story<MultiSelectProps> = (args) => {
+    const [activeItemKeys, setActiveItemKeys] = useState<(string | number)[]>(args.activeItemKeys);
+    return (
+        <FormControl helper={{ text: "Helper Text" }} label={{ children: "Multi-Select", htmlFor: "" }}>
+            <MultiSelectComponent
+                {...args}
+                activeItemKeys={activeItemKeys}
+                onSelectionChange={(keys) => setActiveItemKeys(keys)}
+            />
+        </FormControl>
+    );
+};
+
 export const MultiSelect = MultiSelectTemplate.bind({});
 
 export const WithPlaceholder = MultiSelectTemplate.bind({});
@@ -65,3 +79,5 @@ export const WithOptionsSummarized = MultiSelectTemplate.bind({});
 WithOptionsSummarized.args = {
     type: MultiSelectType.Summarized,
 };
+
+export const WithFormControl = MultiSelectFormControlTemplate.bind({});

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -122,7 +122,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
             <AnimatePresence>
                 {open && (
                     <motion.div
-                        className="tw-absolute tw-left-0 tw-w-full tw-overflow-hidden tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-mt-2 tw-z-10"
+                        className="tw-absolute tw-left-0 tw-w-full tw-overflow-hidden tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-mt-2 tw-z-10 tw-bg-base"
                         key="content"
                         initial={{ height: 0 }}
                         animate={{ height: "auto" }}


### PR DESCRIPTION
Add a non-transparent background to the multi-select dropdown menu. The easiest way to see the issue that this pr solves is to view the "MultiSelect With FormControl" storybook and remove the "tw-bg-base" class