### PR TITLE
feat: Flyout min height

### DIFF
--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -317,3 +317,9 @@ WithRenderFunctionTrigger.argTypes = {
     trigger: { table: { disable: true } },
     decorator: { table: { disable: true } },
 };
+
+export const WithContentMinHeight = FlyoutTemplate.bind({});
+
+WithContentMinHeight.args = {
+    contentMinHeight: '200px',
+};

--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -321,5 +321,5 @@ WithRenderFunctionTrigger.argTypes = {
 export const WithContentMinHeight = FlyoutTemplate.bind({});
 
 WithContentMinHeight.args = {
-    contentMinHeight: '200px',
+    contentMinHeight: "200px",
 };

--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -321,5 +321,5 @@ WithRenderFunctionTrigger.argTypes = {
 export const WithContentMinHeight = FlyoutTemplate.bind({});
 
 WithContentMinHeight.args = {
-    contentMinHeight: "200px",
+    contentMinHeight: 200,
 };

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -46,6 +46,7 @@ export type FlyoutProps = PropsWithChildren<{
     onOpenChange: (isOpen: boolean) => void;
     fixedHeader?: ReactNode;
     fixedFooter?: ReactNode;
+    contentMinHeight?: string;
     /**
      * The legacy footer buttons section inside of the flyout will be deleted in the future.
      * @deprecated Pass the FlyoutFooter component with buttons to the Flyout component.
@@ -67,6 +68,7 @@ export const Flyout: FC<FlyoutProps> = ({
     fitContent = false,
     fixedHeader,
     fixedFooter,
+    contentMinHeight = '0px',
     legacyFooter = true,
 }) => {
     const state = useOverlayTriggerState({ isOpen, onOpenChange });
@@ -146,6 +148,7 @@ export const Flyout: FC<FlyoutProps> = ({
                             ref={overlayRef}
                             scrollRef={scrollRef}
                             fitContent={fitContent}
+                            contentMinHeight={contentMinHeight}
                         >
                             {children}
                         </Overlay>

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -46,7 +46,7 @@ export type FlyoutProps = PropsWithChildren<{
     onOpenChange: (isOpen: boolean) => void;
     fixedHeader?: ReactNode;
     fixedFooter?: ReactNode;
-    contentMinHeight?: string;
+    contentMinHeight?: number;
     /**
      * The legacy footer buttons section inside of the flyout will be deleted in the future.
      * @deprecated Pass the FlyoutFooter component with buttons to the Flyout component.
@@ -68,7 +68,7 @@ export const Flyout: FC<FlyoutProps> = ({
     fitContent = false,
     fixedHeader,
     fixedFooter,
-    contentMinHeight = "0px",
+    contentMinHeight,
     legacyFooter = true,
 }) => {
     const state = useOverlayTriggerState({ isOpen, onOpenChange });

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -68,7 +68,7 @@ export const Flyout: FC<FlyoutProps> = ({
     fitContent = false,
     fixedHeader,
     fixedFooter,
-    contentMinHeight = '0px',
+    contentMinHeight = "0px",
     legacyFooter = true,
 }) => {
     const state = useOverlayTriggerState({ isOpen, onOpenChange });

--- a/src/components/Flyout/Overlay.tsx
+++ b/src/components/Flyout/Overlay.tsx
@@ -57,7 +57,7 @@ const OverlayComponent: ForwardRefRenderFunction<HTMLDivElement, OverlayProps> =
                         !fixedFooter && "tw-rounded-b",
                     ])}
                     style={{
-                        minHeight: contentMinHeight,
+                        minHeight: `${contentMinHeight}px`,
                     }}
                 >
                     {title && (

--- a/src/components/Flyout/Overlay.tsx
+++ b/src/components/Flyout/Overlay.tsx
@@ -30,6 +30,7 @@ const OverlayComponent: ForwardRefRenderFunction<HTMLDivElement, OverlayProps> =
         fixedHeader,
         fixedFooter,
         fitContent,
+        contentMinHeight,
     },
     ref,
 ) => {
@@ -55,6 +56,9 @@ const OverlayComponent: ForwardRefRenderFunction<HTMLDivElement, OverlayProps> =
                         !fixedHeader && "tw-rounded-t",
                         !fixedFooter && "tw-rounded-b",
                     ])}
+                    style={{
+                        minHeight: contentMinHeight,
+                    }}
                 >
                     {title && (
                         <div className="tw-flex tw-justify-between tw-flex-wrap tw-gap-3 tw-p-8">


### PR DESCRIPTION
This adds a `minHeight` style prop for the Flyout content via a `contentMinHeight` component prop
[Loom demo](https://www.loom.com/share/df05651b51e9412fa2a846de835cbaeb)