### PR TITLE
fix(AssetInput): flyout width is calculated incorrectly

### DIFF
--- a/src/components/AssetInput/SingleAsset/SelectedAsset.spec.tsx
+++ b/src/components/AssetInput/SingleAsset/SelectedAsset.spec.tsx
@@ -1,0 +1,47 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { mount } from "@cypress/react";
+import React from "react";
+import { assetInputActions } from "../asset-input-actions";
+import { AssetInputSize } from "../AssetInput";
+import { EXAMPLE_IMAGES } from "../example-assets";
+import { SelectedAsset } from "./SelectedAsset";
+
+const SELECTED_ASSET_ID = "[data-test-id=asset-single-input]";
+const SELECTED_ASSET_FLYOUT_ID = "[data-test-id=asset-single-input-flyout]";
+
+describe("SelectedAsset Component", () => {
+    it("renders selected asset without crashing", () => {
+        mount(
+            <SelectedAsset
+                isLoading={false}
+                asset={EXAMPLE_IMAGES[0]}
+                size={AssetInputSize.Small}
+                actions={assetInputActions}
+            />,
+        );
+        cy.get(SELECTED_ASSET_ID).should("exist");
+    });
+
+    it("calculates the appropriate width for the flyout on resize", () => {
+        mount(
+            <div style={{ width: 0 }} id="resize-container">
+                <SelectedAsset
+                    isLoading={false}
+                    asset={EXAMPLE_IMAGES[0]}
+                    size={AssetInputSize.Small}
+                    actions={assetInputActions}
+                />
+            </div>,
+        );
+        cy.get("#resize-container").then(($container) => {
+            $container.css("width", 500);
+        });
+        cy.get(SELECTED_ASSET_ID).click();
+        cy.get(SELECTED_ASSET_FLYOUT_ID).invoke("width").should("eq", 500);
+        cy.get("#resize-container").then(($container) => {
+            $container.css("width", 300);
+        });
+        cy.get(SELECTED_ASSET_FLYOUT_ID).invoke("width").should("eq", 300);
+    });
+});

--- a/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
+++ b/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
@@ -39,13 +39,19 @@ export const SelectedAsset: FC<Required<SelectedAssetProps>> = ({ asset, size, a
 
     const [flyoutWidth, setFlyoutWidth] = useState(0);
 
-    const calcFlyoutWidth = () => {
-        setFlyoutWidth(buttonRef.current?.getBoundingClientRect().width || 0);
-    };
-
     useEffect(() => {
-        calcFlyoutWidth();
-        window.addEventListener("resize", calcFlyoutWidth, false);
+        const calculateFlyoutWidth = () => {
+            const calculatedWidth = buttonRef.current?.getBoundingClientRect().width ?? 0;
+            setTimeout(() => setFlyoutWidth(calculatedWidth), 0);
+        };
+        const resizeObserver = new ResizeObserver(calculateFlyoutWidth);
+        if (buttonRef.current) {
+            resizeObserver.observe(buttonRef.current);
+        }
+
+        return () => {
+            resizeObserver.disconnect();
+        };
     }, []);
 
     return (
@@ -116,6 +122,7 @@ export const SelectedAsset: FC<Required<SelectedAssetProps>> = ({ asset, size, a
                             width: flyoutWidth,
                         }}
                         className="tw-absolute tw-left-auto tw-w-full tw-overflow-hidden tw-box-border tw-p-0 tw-shadow-mid tw-list-none tw-m-0 tw-mt-2 tw-z-20"
+                        data-test-id="asset-single-input-flyout"
                         key={`asset-input-menu-${menuId}`}
                         initial={{ height: 0 }}
                         animate={{ height: "auto" }}


### PR DESCRIPTION
On component mount the width is sometimes 0  when the parent container has `display:none` applied. (e.g. in Tabs, if the the parent tab container is not active).

Fix: applied a resize observer to keep the width calculation always up-to-date.