### PR TITLE
feat(RichTextEditor): enable controls customization

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.spec.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.spec.tsx
@@ -4,13 +4,15 @@ import { mount } from "@cypress/react";
 import { ELEMENT_PARAGRAPH } from "@udecode/plate";
 import React, { FC, useState } from "react";
 import { ON_SAVE_DELAY_IN_MS, RichTextEditor, RichTextEditorProps } from "./RichTextEditor";
+import { EditorActions } from "./utils/actions";
 import { textStyleClassnames, TextStyles } from "./utils/getTextStyles";
 
 const RICH_TEXT_EDITOR = "[data-test-id=rich-text-editor]";
 const TOOLBAR = "[data-test-id=toolbar]";
-const TEXT_ALIGNMENT_BUTTONS = "[data-test-id=toolbar-group-1]";
-const TEXT_MARK_BUTTONS = "[data-test-id=toolbar-group-2]";
-const TEXT_ELEMENT_BUTTONS = "[data-test-id=toolbar-group-3]";
+const TOOLBAR_GROUP_0 = "[data-test-id=toolbar-group-0]";
+const TOOLBAR_GROUP_1 = "[data-test-id=toolbar-group-1]";
+const TOOLBAR_GROUP_2 = "[data-test-id=toolbar-group-2]";
+const TOOLBAR_GROUP_3 = "[data-test-id=toolbar-group-3]";
 const TEXTSTYLE_DROPDOWN_TRIGGER = "[data-test-id=textstyle-dropdown-trigger]";
 const TEXTSTYLE_OPTION = "[data-test-id=textstyle-option]";
 const CHECKBOX_INPUT = "[data-test-id=checkbox-input]";
@@ -84,12 +86,24 @@ describe("RichTextEditor Component", () => {
         cy.get(TOOLBAR).should("not.be.visible");
     });
 
+    it("renders a toolbar with custom controls", () => {
+        const actions = [[EditorActions.LINK], [EditorActions.ITALIC, EditorActions.BOLD], [EditorActions.LINK]];
+        mount(<RichTextEditor actions={actions} />);
+
+        insertTextAndOpenToolbar();
+        cy.get(TOOLBAR).should("be.visible");
+        cy.get(TOOLBAR_GROUP_0).find("span").should("have.length", 1);
+        cy.get(TOOLBAR_GROUP_1).find("span").should("have.length", 2);
+        cy.get(TOOLBAR_GROUP_2).find("span").should("have.length", 1);
+        cy.get(TOOLBAR_GROUP_3).should("not.exist");
+    });
+
     it("renders a bold text", () => {
         mount(<RichTextEditor />);
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_MARK_BUTTONS).children().eq(0).click();
+        cy.get(TOOLBAR_GROUP_2).children().eq(0).click();
         cy.get("[contenteditable=true]").should("include.html", "tw-font-bold");
     });
 
@@ -98,7 +112,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_MARK_BUTTONS).children().eq(1).click();
+        cy.get(TOOLBAR_GROUP_2).children().eq(1).click();
         cy.get("[contenteditable=true]").should("include.html", "tw-italic");
     });
 
@@ -107,7 +121,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_MARK_BUTTONS).children().eq(2).click();
+        cy.get(TOOLBAR_GROUP_2).children().eq(2).click();
         cy.get("[contenteditable=true]").should("include.html", "tw-underline");
     });
 
@@ -116,7 +130,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_MARK_BUTTONS).children().eq(3).click();
+        cy.get(TOOLBAR_GROUP_2).children().eq(3).click();
         cy.get("[contenteditable=true]").should("include.html", "tw-line-through");
     });
 
@@ -125,7 +139,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_MARK_BUTTONS).children().eq(4).click();
+        cy.get(TOOLBAR_GROUP_2).children().eq(4).click();
         cy.get("[contenteditable=true]").should(
             "include.html",
             "tw-table-cell tw-rounded tw-text-xs tw-bg-black-5 tw-text-violet-90 tw-m-0 tw-px-2 tw-py-0.5",
@@ -137,7 +151,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_ELEMENT_BUTTONS).children().eq(1).click();
+        cy.get(TOOLBAR_GROUP_3).children().eq(1).click();
         cy.get("[contenteditable=true]").should("include.html", "<ul");
     });
 
@@ -146,7 +160,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_ELEMENT_BUTTONS).children().eq(2).click();
+        cy.get(TOOLBAR_GROUP_3).children().eq(2).click();
         cy.get("[contenteditable=true]").should("include.html", "<ol");
     });
 
@@ -155,7 +169,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_ALIGNMENT_BUTTONS).children().eq(2).click();
+        cy.get(TOOLBAR_GROUP_1).children().eq(2).click();
         cy.get("[contenteditable=true]").should("include.html", "text-align: right");
     });
 
@@ -198,7 +212,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_MARK_BUTTONS).children().eq(5).click();
+        cy.get(TOOLBAR_GROUP_2).children().eq(5).click();
         cy.get(CHECKBOX_INPUT).check().should("be.checked");
     });
 
@@ -208,7 +222,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_MARK_BUTTONS)
+        cy.get(TOOLBAR_GROUP_2)
             .children()
             .eq(0)
             .click()
@@ -224,7 +238,7 @@ describe("RichTextEditor Component", () => {
 
         insertTextAndOpenToolbar();
         cy.get(TOOLBAR).should("be.visible");
-        cy.get(TEXT_ELEMENT_BUTTONS)
+        cy.get(TOOLBAR_GROUP_3)
             .children()
             .eq(1)
             .click()

--- a/src/components/RichTextEditor/RichTextEditor.spec.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.spec.tsx
@@ -8,9 +8,9 @@ import { textStyleClassnames, TextStyles } from "./utils/getTextStyles";
 
 const RICH_TEXT_EDITOR = "[data-test-id=rich-text-editor]";
 const TOOLBAR = "[data-test-id=toolbar]";
-const TEXT_ALIGNMENT_BUTTONS = "[data-test-id=text-alignment-buttons]";
-const TEXT_MARK_BUTTONS = "[data-test-id=text-mark-buttons]";
-const TEXT_ELEMENT_BUTTONS = "[data-test-id=text-element-buttons]";
+const TEXT_ALIGNMENT_BUTTONS = "[data-test-id=toolbar-group-1]";
+const TEXT_MARK_BUTTONS = "[data-test-id=toolbar-group-2]";
+const TEXT_ELEMENT_BUTTONS = "[data-test-id=toolbar-group-3]";
 const TEXTSTYLE_DROPDOWN_TRIGGER = "[data-test-id=textstyle-dropdown-trigger]";
 const TEXTSTYLE_OPTION = "[data-test-id=textstyle-option]";
 const CHECKBOX_INPUT = "[data-test-id=checkbox-input]";

--- a/src/components/RichTextEditor/RichTextEditor.stories.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.stories.tsx
@@ -113,6 +113,10 @@ export const WithCustomControls: Story<RichTextEditorProps> = (args: RichTextEdi
 );
 WithCustomControls.args = {
     value: IPSUM,
-    actions: [[EditorActions.TEXT_STYLES], [EditorActions.ITALIC, EditorActions.BOLD, EditorActions.UNDERLINE]],
+    actions: [
+        [EditorActions.LINK],
+        [EditorActions.ITALIC, EditorActions.BOLD, EditorActions.UNDERLINE],
+        [EditorActions.ORDERED_LIST, EditorActions.UNORDERED_LIST],
+    ],
 };
 WithCustomControls.argTypes = { value: { type: "string" } };

--- a/src/components/RichTextEditor/RichTextEditor.stories.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.stories.tsx
@@ -3,7 +3,8 @@
 import { Meta, Story } from "@storybook/react";
 import React from "react";
 import { RichTextEditor as RichTextEditorComponent, RichTextEditorProps } from "./RichTextEditor";
-import { checkboxValue, htmlValue, value } from "./utils/exampleValues";
+import { EditorActions } from "./utils/actions";
+import { checkboxValue, htmlValue, IPSUM, value } from "./utils/exampleValues";
 import { TextStyles } from "./utils/getTextStyles";
 
 // eslint-disable-next-line import/no-default-export
@@ -106,3 +107,12 @@ WithChecklist.args = {
     value: JSON.stringify(checkboxValue),
 };
 WithChecklist.argTypes = { value: { type: "string" } };
+
+export const WithCustomControls: Story<RichTextEditorProps> = (args: RichTextEditorProps) => (
+    <RichTextEditorComponent {...args} />
+);
+WithCustomControls.args = {
+    value: IPSUM,
+    actions: [[EditorActions.TEXT_STYLES], [EditorActions.ITALIC, EditorActions.BOLD, EditorActions.UNDERLINE]],
+};
+WithCustomControls.argTypes = { value: { type: "string" } };

--- a/src/components/RichTextEditor/RichTextEditor.stories.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.stories.tsx
@@ -12,6 +12,7 @@ export default {
     title: "Components/Rich Text Editor",
     component: RichTextEditorComponent,
     args: {
+        value: JSON.stringify(value),
         placeholder: "Some placeholder",
         readonly: false,
         clear: false,
@@ -19,43 +20,34 @@ export default {
     argTypes: {
         onTextChange: { action: "onTextChange" },
         onBlur: { action: "onBlur" },
+        vale: { type: "string" },
     },
 } as Meta;
 
-export const RichTextEditor: Story<RichTextEditorProps> = (args: RichTextEditorProps) => (
+const RichTextEditorTemplate: Story<RichTextEditorProps> = (args: RichTextEditorProps) => (
     <RichTextEditorComponent {...args} />
 );
-RichTextEditor.args = { value: JSON.stringify(value) };
 
-export const WithReadonlyState: Story<RichTextEditorProps> = (args: RichTextEditorProps) => (
-    <RichTextEditorComponent {...args} />
-);
+export const RichTextEditor = RichTextEditorTemplate.bind({});
+
+export const WithReadonlyState = RichTextEditorTemplate.bind({});
 WithReadonlyState.args = {
     readonly: true,
-    value: JSON.stringify(value),
 };
-WithReadonlyState.argTypes = { value: { type: "string" } };
 
-export const RichTextWithHTML: Story<RichTextEditorProps> = (args: RichTextEditorProps) => (
-    <RichTextEditorComponent {...args} />
-);
+export const RichTextWithHTML = RichTextEditorTemplate.bind({});
 RichTextWithHTML.args = {
     value: htmlValue,
 };
-RichTextWithHTML.argTypes = { value: { type: "string" } };
 
 export const RichTextEditorFlex: Story<RichTextEditorProps> = (args: RichTextEditorProps) => (
     <div className="tw-flex">
         <RichTextEditorComponent {...args} />
     </div>
 );
-RichTextEditorFlex.argTypes = { value: { type: "string" } };
 
-export const WithCustomTextStyle: Story<RichTextEditorProps> = (args: RichTextEditorProps) => (
-    <RichTextEditorComponent {...args} />
-);
+export const WithCustomTextStyle = RichTextEditorTemplate.bind({});
 WithCustomTextStyle.args = {
-    value: JSON.stringify(value),
     textStyles: [
         { type: TextStyles.ELEMENT_HEADING1, className: "tw-text-7xl tw-font-bold tw-text-green-80" },
         { type: TextStyles.ELEMENT_HEADING2, className: "tw-text-5xl tw-font-bold tw-text-violet-60" },
@@ -65,7 +57,6 @@ WithCustomTextStyle.args = {
         { type: TextStyles.ELEMENT_CUSTOM2, className: "tw-underline tw-text-black-80" },
     ],
 };
-WithCustomTextStyle.argTypes = { value: { type: "string" } };
 
 export const MultipleRichTextEditors: Story<RichTextEditorProps> = () => (
     <div className="tw-grid tw-grid-cols-2 tw-gap-2">
@@ -100,17 +91,12 @@ export const MultipleRichTextEditors: Story<RichTextEditorProps> = () => (
     </div>
 );
 
-export const WithChecklist: Story<RichTextEditorProps> = (args: RichTextEditorProps) => (
-    <RichTextEditorComponent {...args} />
-);
+export const WithChecklist = RichTextEditorTemplate.bind({});
 WithChecklist.args = {
     value: JSON.stringify(checkboxValue),
 };
-WithChecklist.argTypes = { value: { type: "string" } };
 
-export const WithCustomControls: Story<RichTextEditorProps> = (args: RichTextEditorProps) => (
-    <RichTextEditorComponent {...args} />
-);
+export const WithCustomControls = RichTextEditorTemplate.bind({});
 WithCustomControls.args = {
     value: IPSUM,
     actions: [
@@ -119,4 +105,3 @@ WithCustomControls.args = {
         [EditorActions.ORDERED_LIST, EditorActions.UNORDERED_LIST],
     ],
 };
-WithCustomControls.argTypes = { value: { type: "string" } };

--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -6,6 +6,7 @@ import { debounce } from "@utilities/debounce";
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import { EditableProps } from "slate-react/dist/components/editable";
 import { Toolbar } from "./Toolbar";
+import { EditorActions } from "./utils/actions";
 import { getEditorConfig } from "./utils/getEditorConfig";
 import { TextStyleType } from "./utils/getTextStyles";
 import { EMPTY_RICH_TEXT_VALUE, parseRawValue } from "./utils/parseRawValue";
@@ -19,6 +20,7 @@ export type RichTextEditorProps = {
     readonly?: boolean;
     clear?: boolean;
     textStyles?: TextStyleType[];
+    actions?: EditorActions[][];
 };
 
 export const ON_SAVE_DELAY_IN_MS = 500;
@@ -30,6 +32,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
     readonly = false,
     clear = false,
     textStyles,
+    actions = [],
     onTextChange,
     onBlur,
 }) => {
@@ -78,7 +81,7 @@ export const RichTextEditor: FC<RichTextEditorProps> = ({
                 editableProps={editableProps}
                 plugins={getEditorConfig(textStyles)}
             >
-                <Toolbar editorId={editorId} textStyles={textStyles} />
+                <Toolbar editorId={editorId} textStyles={textStyles} actions={actions} />
             </Plate>
         </div>
     );

--- a/src/components/RichTextEditor/Toolbar.tsx
+++ b/src/components/RichTextEditor/Toolbar.tsx
@@ -7,7 +7,6 @@ import {
     IconListBullets,
     IconListChecklist,
     IconListNumbers,
-    IconSnippet,
     IconStrikethrough,
     IconTextAlignCenter,
     IconTextAlignJustify,
@@ -32,32 +31,55 @@ import {
     MARK_UNDERLINE,
     usePlateEditorRef,
 } from "@udecode/plate";
-import React, { FC } from "react";
+import React, { FC, ReactElement } from "react";
 import { ELEMENT_CHECK_ITEM } from "./plugins/checkboxListPlugin";
 import { TextStyleDropdown } from "./TextStyleDropdown/TextStyleDropdown";
+import { defaultActions, EditorActions } from "./utils/actions";
 import { TextStyleType } from "./utils/getTextStyles";
 
 type ToolbarProps = {
     editorId?: string;
     textStyles?: TextStyleType[];
+    actions?: EditorActions[][];
 };
 
-type ButtonGroupProps = {
-    testId?: string;
-    children: JSX.Element | JSX.Element[];
-};
-
-export const Toolbar: FC<ToolbarProps> = ({ editorId, textStyles }) => {
+export const Toolbar: FC<ToolbarProps> = ({ editorId, textStyles, actions = [] }) => {
     const editor = usePlateEditorRef(editorId);
 
-    const ButtonGroup: FC<ButtonGroupProps> = ({ testId, children }) => (
-        <div
-            data-test-id={testId}
-            className="tw-flex tw-items-center tw-border-r last:tw-border-r-0 tw-px-3 tw-py-2 tw-border-black-5"
-        >
-            {children}
-        </div>
-    );
+    const toolbarActions = actions.length > 0 ? actions : defaultActions;
+
+    console.log({ toolbarActions });
+
+    const toolbarComponents: Record<EditorActions, ReactElement> = {
+        [EditorActions.TEXT_STYLES]: <TextStyleDropdown editorId={editorId} textStyles={textStyles} />,
+        [EditorActions.ALIGN_LEFT]: <AlignToolbarButton value="left" icon={<IconTextAlignLeft />} />,
+        [EditorActions.ALIGN_CENTER]: <AlignToolbarButton value="center" icon={<IconTextAlignCenter />} />,
+        [EditorActions.ALIGN_RIGHT]: <AlignToolbarButton value="right" icon={<IconTextAlignRight />} />,
+        [EditorActions.ALIGN_JUSTIFY]: <AlignToolbarButton value="justify" icon={<IconTextAlignJustify />} />,
+        [EditorActions.BOLD]: <MarkToolbarButton type={getPluginType(editor, MARK_BOLD)} icon={<IconBold />} />,
+        [EditorActions.ITALIC]: <MarkToolbarButton type={getPluginType(editor, MARK_ITALIC)} icon={<IconItalic />} />,
+        [EditorActions.UNDERLINE]: (
+            <MarkToolbarButton type={getPluginType(editor, MARK_UNDERLINE)} icon={<IconUnderline />} />
+        ),
+        [EditorActions.STRIKETHROUGH]: (
+            <MarkToolbarButton type={getPluginType(editor, MARK_STRIKETHROUGH)} icon={<IconStrikethrough />} />
+        ),
+        [EditorActions.CODE]: (
+            <MarkToolbarButton type={getPluginType(editor, MARK_CODE)} icon={<IconStrikethrough />} />
+        ),
+        [EditorActions.CHECK_ITEM]: (
+            <BlockToolbarButton type={getPluginType(editor, ELEMENT_CHECK_ITEM)} icon={<IconListChecklist />} />
+        ),
+        [EditorActions.LINK]: <LinkToolbarButton icon={<IconLink />} />,
+        [EditorActions.ORDERED_LIST]: (
+            <ListToolbarButton type={getPluginType(editor, ELEMENT_OL)} icon={<IconListNumbers />} />
+        ),
+        [EditorActions.UNORDERED_LIST]: (
+            <ListToolbarButton type={getPluginType(editor, ELEMENT_UL)} icon={<IconListBullets />} />
+        ),
+    };
+
+    console.log({ toolbarComponents });
 
     return (
         <BalloonToolbar
@@ -74,30 +96,17 @@ export const Toolbar: FC<ToolbarProps> = ({ editorId, textStyles }) => {
                 data-test-id="toolbar"
                 className="tw-flex tw-p-0.5 tw-items-center tw-bg-white tw-rounded tw-shadow-mid tw-gap-0.5"
             >
-                <ButtonGroup testId="text-style-buttons">
-                    <TextStyleDropdown editorId={editorId} textStyles={textStyles} />
-                </ButtonGroup>
-                <ButtonGroup testId="text-alignment-buttons">
-                    <AlignToolbarButton value="left" icon={<IconTextAlignLeft />} />
-                    <AlignToolbarButton value="center" icon={<IconTextAlignCenter />} />
-                    <AlignToolbarButton value="right" icon={<IconTextAlignRight />} />
-                    <AlignToolbarButton value="justify" icon={<IconTextAlignJustify />} />
-                </ButtonGroup>
-
-                <ButtonGroup testId="text-mark-buttons">
-                    <MarkToolbarButton type={getPluginType(editor, MARK_BOLD)} icon={<IconBold />} />
-                    <MarkToolbarButton type={getPluginType(editor, MARK_ITALIC)} icon={<IconItalic />} />
-                    <MarkToolbarButton type={getPluginType(editor, MARK_UNDERLINE)} icon={<IconUnderline />} />
-                    <MarkToolbarButton type={getPluginType(editor, MARK_STRIKETHROUGH)} icon={<IconStrikethrough />} />
-                    <MarkToolbarButton type={getPluginType(editor, MARK_CODE)} icon={<IconSnippet />} />
-                    <BlockToolbarButton type={getPluginType(editor, ELEMENT_CHECK_ITEM)} icon={<IconListChecklist />} />
-                </ButtonGroup>
-
-                <ButtonGroup testId="text-element-buttons">
-                    <LinkToolbarButton icon={<IconLink />} />
-                    <ListToolbarButton type={getPluginType(editor, ELEMENT_UL)} icon={<IconListBullets />} />
-                    <ListToolbarButton type={getPluginType(editor, ELEMENT_OL)} icon={<IconListNumbers />} />
-                </ButtonGroup>
+                {toolbarActions.map((actions, index) => (
+                    <div
+                        key={index}
+                        data-test-id={`toolbar-group-${index}`}
+                        className="tw-flex tw-items-center tw-border-r last:tw-border-r-0 tw-px-3 tw-py-2 tw-border-black-5"
+                    >
+                        {actions.map((action, index) => (
+                            <React.Fragment key={index}>{toolbarComponents[action]}</React.Fragment>
+                        ))}
+                    </div>
+                ))}
             </div>
         </BalloonToolbar>
     );

--- a/src/components/RichTextEditor/Toolbar.tsx
+++ b/src/components/RichTextEditor/Toolbar.tsx
@@ -29,6 +29,7 @@ import {
     MARK_ITALIC,
     MARK_STRIKETHROUGH,
     MARK_UNDERLINE,
+    PlateEditor,
     usePlateEditorRef,
 } from "@udecode/plate";
 import React, { FC, ReactElement } from "react";
@@ -43,37 +44,40 @@ type ToolbarProps = {
     actions?: EditorActions[][];
 };
 
+const toolbarComponents = (
+    editor: PlateEditor,
+    editorId?: string,
+    textStyles?: TextStyleType[],
+): Record<EditorActions, ReactElement> => ({
+    [EditorActions.TEXT_STYLES]: <TextStyleDropdown editorId={editorId} textStyles={textStyles} />,
+    [EditorActions.ALIGN_LEFT]: <AlignToolbarButton value="left" icon={<IconTextAlignLeft />} />,
+    [EditorActions.ALIGN_CENTER]: <AlignToolbarButton value="center" icon={<IconTextAlignCenter />} />,
+    [EditorActions.ALIGN_RIGHT]: <AlignToolbarButton value="right" icon={<IconTextAlignRight />} />,
+    [EditorActions.ALIGN_JUSTIFY]: <AlignToolbarButton value="justify" icon={<IconTextAlignJustify />} />,
+    [EditorActions.BOLD]: <MarkToolbarButton type={getPluginType(editor, MARK_BOLD)} icon={<IconBold />} />,
+    [EditorActions.ITALIC]: <MarkToolbarButton type={getPluginType(editor, MARK_ITALIC)} icon={<IconItalic />} />,
+    [EditorActions.UNDERLINE]: (
+        <MarkToolbarButton type={getPluginType(editor, MARK_UNDERLINE)} icon={<IconUnderline />} />
+    ),
+    [EditorActions.STRIKETHROUGH]: (
+        <MarkToolbarButton type={getPluginType(editor, MARK_STRIKETHROUGH)} icon={<IconStrikethrough />} />
+    ),
+    [EditorActions.CODE]: <MarkToolbarButton type={getPluginType(editor, MARK_CODE)} icon={<IconStrikethrough />} />,
+    [EditorActions.CHECK_ITEM]: (
+        <BlockToolbarButton type={getPluginType(editor, ELEMENT_CHECK_ITEM)} icon={<IconListChecklist />} />
+    ),
+    [EditorActions.LINK]: <LinkToolbarButton icon={<IconLink />} />,
+    [EditorActions.ORDERED_LIST]: (
+        <ListToolbarButton type={getPluginType(editor, ELEMENT_OL)} icon={<IconListNumbers />} />
+    ),
+    [EditorActions.UNORDERED_LIST]: (
+        <ListToolbarButton type={getPluginType(editor, ELEMENT_UL)} icon={<IconListBullets />} />
+    ),
+});
+
 export const Toolbar: FC<ToolbarProps> = ({ editorId, textStyles, actions = [] }) => {
     const editor = usePlateEditorRef(editorId);
     const toolbarActions = actions.length > 0 ? actions : defaultActions;
-    const toolbarComponents: Record<EditorActions, ReactElement> = {
-        [EditorActions.TEXT_STYLES]: <TextStyleDropdown editorId={editorId} textStyles={textStyles} />,
-        [EditorActions.ALIGN_LEFT]: <AlignToolbarButton value="left" icon={<IconTextAlignLeft />} />,
-        [EditorActions.ALIGN_CENTER]: <AlignToolbarButton value="center" icon={<IconTextAlignCenter />} />,
-        [EditorActions.ALIGN_RIGHT]: <AlignToolbarButton value="right" icon={<IconTextAlignRight />} />,
-        [EditorActions.ALIGN_JUSTIFY]: <AlignToolbarButton value="justify" icon={<IconTextAlignJustify />} />,
-        [EditorActions.BOLD]: <MarkToolbarButton type={getPluginType(editor, MARK_BOLD)} icon={<IconBold />} />,
-        [EditorActions.ITALIC]: <MarkToolbarButton type={getPluginType(editor, MARK_ITALIC)} icon={<IconItalic />} />,
-        [EditorActions.UNDERLINE]: (
-            <MarkToolbarButton type={getPluginType(editor, MARK_UNDERLINE)} icon={<IconUnderline />} />
-        ),
-        [EditorActions.STRIKETHROUGH]: (
-            <MarkToolbarButton type={getPluginType(editor, MARK_STRIKETHROUGH)} icon={<IconStrikethrough />} />
-        ),
-        [EditorActions.CODE]: (
-            <MarkToolbarButton type={getPluginType(editor, MARK_CODE)} icon={<IconStrikethrough />} />
-        ),
-        [EditorActions.CHECK_ITEM]: (
-            <BlockToolbarButton type={getPluginType(editor, ELEMENT_CHECK_ITEM)} icon={<IconListChecklist />} />
-        ),
-        [EditorActions.LINK]: <LinkToolbarButton icon={<IconLink />} />,
-        [EditorActions.ORDERED_LIST]: (
-            <ListToolbarButton type={getPluginType(editor, ELEMENT_OL)} icon={<IconListNumbers />} />
-        ),
-        [EditorActions.UNORDERED_LIST]: (
-            <ListToolbarButton type={getPluginType(editor, ELEMENT_UL)} icon={<IconListBullets />} />
-        ),
-    };
 
     return (
         <BalloonToolbar
@@ -97,7 +101,9 @@ export const Toolbar: FC<ToolbarProps> = ({ editorId, textStyles, actions = [] }
                         className="tw-flex tw-items-center tw-border-r last:tw-border-r-0 tw-px-3 tw-py-2 tw-border-black-5"
                     >
                         {actions.map((action, index) => (
-                            <React.Fragment key={index}>{toolbarComponents[action]}</React.Fragment>
+                            <React.Fragment key={index}>
+                                {toolbarComponents(editor, editorId, textStyles)[action]}
+                            </React.Fragment>
                         ))}
                     </div>
                 ))}

--- a/src/components/RichTextEditor/Toolbar.tsx
+++ b/src/components/RichTextEditor/Toolbar.tsx
@@ -45,11 +45,7 @@ type ToolbarProps = {
 
 export const Toolbar: FC<ToolbarProps> = ({ editorId, textStyles, actions = [] }) => {
     const editor = usePlateEditorRef(editorId);
-
     const toolbarActions = actions.length > 0 ? actions : defaultActions;
-
-    console.log({ toolbarActions });
-
     const toolbarComponents: Record<EditorActions, ReactElement> = {
         [EditorActions.TEXT_STYLES]: <TextStyleDropdown editorId={editorId} textStyles={textStyles} />,
         [EditorActions.ALIGN_LEFT]: <AlignToolbarButton value="left" icon={<IconTextAlignLeft />} />,
@@ -78,8 +74,6 @@ export const Toolbar: FC<ToolbarProps> = ({ editorId, textStyles, actions = [] }
             <ListToolbarButton type={getPluginType(editor, ELEMENT_UL)} icon={<IconListBullets />} />
         ),
     };
-
-    console.log({ toolbarComponents });
 
     return (
         <BalloonToolbar

--- a/src/components/RichTextEditor/utils/actions.ts
+++ b/src/components/RichTextEditor/utils/actions.ts
@@ -1,0 +1,32 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export enum EditorActions {
+    TEXT_STYLES = "text-styles",
+    ALIGN_LEFT = "align-left",
+    ALIGN_CENTER = "align-center",
+    ALIGN_RIGHT = "align-right",
+    ALIGN_JUSTIFY = "align-justify",
+    BOLD = "bold",
+    ITALIC = "italic",
+    UNDERLINE = "underline",
+    STRIKETHROUGH = "strikethrough",
+    CODE = "code",
+    CHECK_ITEM = "check-item",
+    LINK = "link",
+    ORDERED_LIST = "ordered-list",
+    UNORDERED_LIST = "unordered-list",
+}
+
+export const defaultActions = [
+    [EditorActions.TEXT_STYLES],
+    [EditorActions.ALIGN_LEFT, EditorActions.ALIGN_CENTER, EditorActions.ALIGN_RIGHT, EditorActions.ALIGN_JUSTIFY],
+    [
+        EditorActions.BOLD,
+        EditorActions.ITALIC,
+        EditorActions.UNDERLINE,
+        EditorActions.STRIKETHROUGH,
+        EditorActions.CODE,
+        EditorActions.CHECK_ITEM,
+    ],
+    [EditorActions.LINK, EditorActions.UNORDERED_LIST, EditorActions.ORDERED_LIST],
+];

--- a/src/components/RichTextEditor/utils/exampleValues.ts
+++ b/src/components/RichTextEditor/utils/exampleValues.ts
@@ -37,7 +37,7 @@ const createElement = ({ text, element = ELEMENT_PARAGRAPH, mark }: CreateElemen
     };
 };
 
-const IPSUM =
+export const IPSUM =
     "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
 
 export const value = [


### PR DESCRIPTION
This PR enables custom controls for the RTE by introducing a `action` prop. Subarray enable grouping of the controls.

Example:
`<RichTextEditor actions={[['link'],['italic','bold','underline'],['ordered-list','unordered-list']} />`

Result:
<img width="270" alt="Bildschirmfoto 2022-05-02 um 15 59 13" src="https://user-images.githubusercontent.com/11270687/166246503-c99d0767-103c-45ef-ba0c-24bde1ed9b3c.png">


Ticket: https://app.clickup.com/t/2bmxh0x