### PR TITLE
fix(ScrollWrapper): added side spacing

### DIFF
--- a/src/components/ScrollWrapper/ScrollWrapper.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.tsx
@@ -42,7 +42,7 @@ export const ScrollWrapper: FC<ScrollWrapperProps> = ({ direction = ScrollWrappe
             )}
             <div
                 ref={scrollingContainer}
-                className={merge([scrollWrapperDirections[direction], "tw-flex-auto tw-min-h-0"])}
+                className={merge([scrollWrapperDirections[direction], "tw-flex-auto tw-min-h-0 tw--mx-2 tw-px-2"])}
                 {...scrollDivProps}
             >
                 {children}


### PR DESCRIPTION
<img width="463" alt="Screenshot 2022-05-04 at 11 00 15" src="https://user-images.githubusercontent.com/93908356/166651563-3c686493-9e58-4f6d-bfb9-8babad62beb1.png">

Adds some side spacing to the Scroll Wrapper to prevent focus styles and sliders being clipped by the overflow-hidden class