### PR TITLE
feat(Tree): add badge icon to tree node item

### DIFF
--- a/src/components/Tree/Node.tsx
+++ b/src/components/Tree/Node.tsx
@@ -140,7 +140,12 @@ export const Node = ({
                             <span className="tw-flex tw-items-center" data-test-id="node-link-name">
                                 {name}
                                 {badge && (
-                                    <div className="tw-flex tw-justify-center tw-items-center tw-w-8 tw-h-5 tw-ml-2 tw-bg-box-neutral tw-rounded-full">
+                                    <div
+                                        className={merge([
+                                            "tw-flex tw-justify-center tw-items-center tw-w-8 tw-h-5 tw-ml-2 tw-bg-box-neutral tw-rounded-full",
+                                            selected && "tw-bg-transparent",
+                                        ])}
+                                    >
                                         <span>{badge}</span>
                                     </div>
                                 )}

--- a/src/components/Tree/Node.tsx
+++ b/src/components/Tree/Node.tsx
@@ -55,9 +55,9 @@ export const Node = ({
     onDrop,
     treeName,
 }: NodeProps): ReactElement<NodeProps> => {
-    const { id, value, name, label, icon, nodes, actions } = node;
+    const { id, value, name, label, icon, nodes, actions, badge } = node;
     const [{ opacity }, drag] = useDrag({
-        item: { id, value, name, label, icon, nodes, actions },
+        item: { id, value, name, label, icon, nodes, actions, badge },
         collect: (monitor) => ({
             opacity: monitor.isDragging() ? 0.4 : 1,
         }),
@@ -137,7 +137,14 @@ export const Node = ({
                                     ))}
                             </span>
                             {icon && <span>{icon}</span>}
-                            <span data-test-id="node-link-name">{name}</span>
+                            <span className="tw-flex tw-items-center" data-test-id="node-link-name">
+                                {name}
+                                {badge && (
+                                    <div className="tw-flex tw-justify-center tw-items-center tw-w-8 tw-h-5 tw-ml-2 tw-bg-box-neutral tw-rounded-full">
+                                        <span>{badge}</span>
+                                    </div>
+                                )}
+                            </span>
                         </div>
                         <div className="tw-px-1.5">
                             <span

--- a/src/components/Tree/Node.tsx
+++ b/src/components/Tree/Node.tsx
@@ -85,6 +85,22 @@ export const Node = ({
         setShowNodes(!showNodes);
     };
 
+    const insertBadge = () => {
+        console.log(badge);
+
+        return (
+            <div
+                className={merge([
+                    "tw-flex tw-justify-center tw-items-center tw-ml-2",
+                    selected && "tw-bg-transparent",
+                    badge?.props.size && "tw-w-8 tw-h-5 tw-bg-box-neutral tw-rounded-full",
+                ])}
+            >
+                {badge}
+            </div>
+        );
+    };
+
     /* eslint-disable jsx-a11y/anchor-is-valid,jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
     return (
         <li
@@ -139,16 +155,7 @@ export const Node = ({
                             {icon && <span>{icon}</span>}
                             <span className="tw-flex tw-items-center" data-test-id="node-link-name">
                                 {name}
-                                {badge && (
-                                    <div
-                                        className={merge([
-                                            "tw-flex tw-justify-center tw-items-center tw-w-8 tw-h-5 tw-ml-2 tw-bg-box-neutral tw-rounded-full",
-                                            selected && "tw-bg-transparent",
-                                        ])}
-                                    >
-                                        <span>{badge}</span>
-                                    </div>
-                                )}
+                                {badge && insertBadge()}
                             </span>
                         </div>
                         <div className="tw-px-1.5">

--- a/src/components/Tree/Node.tsx
+++ b/src/components/Tree/Node.tsx
@@ -88,6 +88,7 @@ export const Node = ({
     const insertBadge = () => {
         return (
             <div
+                data-test-id="node-badge"
                 className={merge([
                     "tw-flex tw-justify-center tw-items-center tw-ml-2",
                     selected && "tw-bg-transparent",

--- a/src/components/Tree/Node.tsx
+++ b/src/components/Tree/Node.tsx
@@ -86,8 +86,6 @@ export const Node = ({
     };
 
     const insertBadge = () => {
-        console.log(badge);
-
         return (
             <div
                 className={merge([

--- a/src/components/Tree/Tree.spec.tsx
+++ b/src/components/Tree/Tree.spec.tsx
@@ -33,6 +33,7 @@ const NODE_LINK_NAME_ID = "[data-test-id=node-link-name]";
 const TOGGLE_ID = "[data-test-id=toggle]";
 const SUB_TREE_ID = "[data-test-id=sub-tree]";
 const DROP_ZONE_ID = "[data-test-id=drop-zone]";
+const BADGE_ID = "[data-test-id=node-badge]";
 
 describe("Tree Component", () => {
     // TODO check if DropZones are not present when no onDrop props is provided. Refactoring needed first
@@ -114,5 +115,26 @@ describe("Draggable Tree Component", () => {
             const expectedClass = index % 2 === 0 ? "tw-h-[10px]" : "tw-h-auto";
             expect($dropZone).to.have.class(expectedClass);
         });
+    });
+});
+
+describe("Badge Tree Component", () => {
+    beforeEach(() => {
+        mount(<Component nodes={mockNodesFlat} />);
+
+        cy.get(`${NODE_ID} ${TOGGLE_ID}`).click();
+    });
+
+    it("does not render badge", () => {
+        cy.get(`${SUB_TREE_ID} > ${NODE_ID}:first ${BADGE_ID}`).should("not.exist");
+    });
+
+    it("renders icon", () => {
+        cy.get(`${SUB_TREE_ID} > ${NODE_ID}:last ${BADGE_ID}`).should("exist");
+    });
+
+    it("renders badge", () => {
+        cy.get(`${SUB_TREE_ID} > ${NODE_ID}:last ${TOGGLE_ID}`).click();
+        cy.get(`${SUB_TREE_ID} > ${NODE_ID}:last ${BADGE_ID}`).should("exist");
     });
 });

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -8,6 +8,7 @@ import { useId } from "@react-aria/utils";
 import { DraggableItem, DropZonePosition } from "@utilities/dnd";
 import { getReorderedNodes, listToTree } from "@components/Tree/utils";
 import { IconProps } from "@foundation/Icon";
+import { BadgeProps } from "..";
 
 export interface TreeFlatListItem {
     name: string;
@@ -15,7 +16,7 @@ export interface TreeFlatListItem {
     label?: string;
     value?: string;
     actions?: React.ReactNode[];
-    badge?: ReactElement<IconProps>;
+    badge?: ReactElement<BadgeProps>;
     parentId: NullableString;
 }
 

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -16,7 +16,7 @@ export interface TreeFlatListItem {
     label?: string;
     value?: string;
     actions?: React.ReactNode[];
-    badge?: ReactElement<BadgeProps>;
+    badge?: ReactElement<IconProps> | ReactElement<BadgeProps>;
     parentId: NullableString;
 }
 

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -15,6 +15,7 @@ export interface TreeFlatListItem {
     label?: string;
     value?: string;
     actions?: React.ReactNode[];
+    badge?: ReactElement<IconProps>;
     parentId: NullableString;
 }
 

--- a/src/components/Tree/utils/mocks.tsx
+++ b/src/components/Tree/utils/mocks.tsx
@@ -3,6 +3,7 @@ import { IconFile, IconFolder, IconSize, IconSmileysPeople } from "@foundation/I
 import React from "react";
 import { TreeFlatListItem, TreeNodeItem } from "@components/Tree";
 import { DraggableItem } from "@utilities/dnd";
+import { Badge } from "../../..";
 
 export const mockActionMenuBlocks = [
     {
@@ -103,6 +104,7 @@ const testCategoryNodes = [
         value: "https://weare.frontify.com/page/5",
         icon: <IconFile size={IconSize.Size16} />,
         sort: null,
+        badge: <Badge icon={<IconSmileysPeople size={IconSize.Size16} />}></Badge>,
     },
     {
         id: "1-2-3",
@@ -112,6 +114,7 @@ const testCategoryNodes = [
         value: "https://weare.frontify.com/page/6",
         icon: <IconFile size={IconSize.Size16} />,
         sort: null,
+        badge: <Badge>Hello, I am a badge</Badge>,
     },
 ];
 

--- a/src/components/Tree/utils/mocks.tsx
+++ b/src/components/Tree/utils/mocks.tsx
@@ -1,5 +1,5 @@
 import { MenuItemContentSize } from "@components/MenuItem";
-import { IconFile, IconFolder, IconSize } from "@foundation/Icon";
+import { IconFile, IconFolder, IconSize, IconSmileysPeople } from "@foundation/Icon";
 import React from "react";
 import { TreeFlatListItem, TreeNodeItem } from "@components/Tree";
 import { DraggableItem } from "@utilities/dnd";
@@ -141,6 +141,7 @@ export const mockNodesFlat: DraggableItem<TreeFlatListItem>[] = [
         icon: <IconFolder size={IconSize.Size16} />,
         value: "https://weare.frontify.com/document/923#/test",
         sort: null,
+        badge: <IconSmileysPeople size={IconSize.Size16} />,
     },
     ...testCategoryNodes,
 ];


### PR DESCRIPTION
As discussed somewhat in the [Slack thread](https://frontify.slack.com/archives/C02PSJTPA3D/p1650372981299969).

I did the styling as it is in the [design for the Navigation Manager](https://www.figma.com/file/f37w3IPvu5wBpo0GakMNm0/Navigation?node-id=985%3A467784).