### PR TITLE
correct slider component

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -129,7 +129,8 @@ export const Slider: FC<SliderProps> = ({
         >
             <motion.div
                 aria-hidden="true"
-                animate={{ x: `${100 * selectedIndex}%` }}
+                // div border is not included in width so it must be subtracted from translation.
+                animate={{ x: `calc(${100 * selectedIndex}% - ${2 * selectedIndex}px)` }}
                 initial={false}
                 transition={{ type: "tween", duration: 0.3 }}
                 style={{


### PR DESCRIPTION
<img width="267" alt="Screenshot 2022-05-05 at 18 15 16" src="https://user-images.githubusercontent.com/93908356/166967670-de1344f3-9262-4b7f-bbf2-301446e4cdfd.png">

Remove border from translation to prevent over-translating 