### PR TITLE
fix: Fix create new component script template - remove FC

### DIFF
--- a/scripts/templates/component.ts
+++ b/scripts/templates/component.ts
@@ -1,18 +1,21 @@
 import ComponentFileBuilderResponse from "./ComponentFileBuilderResponse";
 import { toKebabCase } from "./transforms";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,import/no-default-export
 export default (componentName: string, componentType: string): ComponentFileBuilderResponse => ({
     content: `/* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC } from "react";
+import React, { PropsWithChildren } from "react";
 
-export type ${componentName}Props = {
-    foo: string;
-};
+export type ${componentName}Props = PropsWithChildren<{ foo: string }>;
 
-export const ${componentName}: FC<${componentName}Props> = ({ foo }) => {
-    return <div data-test-id="${toKebabCase(componentName)}">{foo}</div>;
+export const ${componentName} = ({ foo, children }: ${componentName}Props) => {
+    return (
+        <div data-test-id="${toKebabCase(componentName)}">
+            <div>{foo}</div>
+            {children}
+        </div>
+    );
 };
 `,
     extension: `.tsx`,


### PR DESCRIPTION
I took the liberty of updating this as we decided not to use FC anymore. I think we should update the template when creating new components.

Some feedback about using PropsWithChildren in this template?