### PR TITLE
fix(Tabs): fix overflow scroll

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -15,8 +15,7 @@ import { TabItemProps } from "@components/Tabs/TabItem";
 import { merge } from "@utilities/merge";
 import { IconMore } from "@foundation/Icon";
 import { Badge } from "@components/Badge";
-import { LayoutGroup, motion } from "framer-motion";
-import { useMemoizedId } from "@hooks/useMemoizedId";
+import { motion } from "framer-motion";
 import { useFocusRing } from "@react-aria/focus";
 import { FOCUS_STYLE } from "@utilities/focusStyle";
 
@@ -49,7 +48,6 @@ export const Tabs: FC<TabsProps> = ({ paddingX, size, activeItemId, children, on
     const tabNavRef = useRef<HTMLDivElement | null>(null);
     const [isOverflowing, setIsOverflowing] = useState(false);
     const [isMenuOpened, setIsMenuOpened] = useState(false);
-    const layoutGroupId = useMemoizedId();
 
     const tabs: TabItemProps[] =
         Children.map(children, (child) => {
@@ -181,7 +179,7 @@ export const Tabs: FC<TabsProps> = ({ paddingX, size, activeItemId, children, on
     const { isFocusVisible, focusProps } = useFocusRing();
 
     return (
-        <LayoutGroup id={layoutGroupId}>
+        <>
             <div data-test-id="tabs" className="tw-flex tw-relative tw-border-b tw-border-line">
                 <div
                     ref={tabNavRef}
@@ -229,6 +227,8 @@ export const Tabs: FC<TabsProps> = ({ paddingX, size, activeItemId, children, on
                                 )}
                                 {tab.id === activeItemId && (
                                     <motion.div
+                                        initial={false}
+                                        layoutDependency={activeItemId}
                                         data-test-id="tab-active-highlight"
                                         layoutId="underline"
                                         className="tw-absolute tw-h-[3px] tw-bg-violet-60 tw-rounded-t-x-large tw-w-full tw-bottom-0"
@@ -314,6 +314,6 @@ export const Tabs: FC<TabsProps> = ({ paddingX, size, activeItemId, children, on
                     return cloneElement(child, { ...child.props, active: child.props.id === activeItemId });
                 })}
             </div>
-        </LayoutGroup>
+        </>
     );
 };


### PR DESCRIPTION
This pr fixes an issue where the layout animation occurs if the tab position is changes within the page.
To replicate:
In Arcade:
1. `npm link`
2. `npm run build`

In Clarify:
1. Make sure you have the MARKETPLACE dev flag enabled
2. `npm link @frontify/arcade`
3. `npm run dev`
4. visit [this url](https://dev.frontify.test/marketplace/type/integration/app/237f8362-ec03-4c86-86e3-314b4d0200b6?panel=overview)
5. Toggle between edit & view mode. There should be no animation or overflow bar when the position of the tab inside the page layout changes