### PR TITLE
feat: add Modal.Body padding prop. move Modal padding into parts

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Modal } from "./Modal";
+import { Modal, MODAL_PADDING } from "./Modal";
 import React, { useState } from "react";
 import { Button, ButtonStyle } from "@components/Button";
 import { Story, Meta } from "@storybook/react";
@@ -222,9 +222,20 @@ WithLimitedText.args = { ...ModalTemplate.args, children: <ExampleParagraph /> }
 
 export const BodyWithoutHorizontalPadding = ModalTemplate.bind({});
 
+const ExampleFullWidthBody = () => (
+    <div
+        className={`tw-h-60 tw-bg-black-90 tw-text-white tw-overflow-y-auto ${MODAL_PADDING.top} ${MODAL_PADDING.horizontal} ${MODAL_PADDING.bottom}`}
+    >
+        <ExampleParagraph />
+        <ExampleParagraph />
+        <ExampleParagraph />
+        <ExampleParagraph />
+    </div>
+);
+
 BodyWithoutHorizontalPadding.args = {
     ...ModalTemplate.args,
     horizontalPadding: false,
     pattern: undefined,
-    children: <ExampleParagraph />,
+    children: <ExampleFullWidthBody />,
 };

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -12,7 +12,14 @@ import { PatternDesign, PatternTheme } from "@foundation/Pattern";
 import { IconAcademy, IconAudio, IconIcons } from "@foundation/Icon";
 import { ScrollWrapperDirection } from "@components/ScrollWrapper/types";
 import { OverlayContainer, OverlayProvider } from "@react-aria/overlays";
-import { ModalHeaderProps, ModalHeaderVariant, ModalProps, ModalVisualProps, ModalWidth } from "./types";
+import {
+    ModalBodyProps,
+    ModalHeaderProps,
+    ModalHeaderVariant,
+    ModalProps,
+    ModalVisualProps,
+    ModalWidth,
+} from "./types";
 import { FormControl, FormControlDirection, FormControlStyle } from "@components/FormControl";
 
 // eslint-disable-next-line import/no-default-export
@@ -89,6 +96,13 @@ export default {
             defaultValue: ModalHeaderVariant.Default,
             control: { type: "select" },
         },
+        horizontalPadding: {
+            table: {
+                category: "Layout",
+            },
+            name: "Body Horizontal Padding",
+            defaultValue: true,
+        },
         children: {
             table: {
                 disable: true,
@@ -132,7 +146,7 @@ const ControlledInput = () => {
     );
 };
 
-const ModalTemplate: Story<ModalProps & ModalVisualProps & ModalHeaderProps> = (args) => {
+const ModalTemplate: Story<ModalProps & ModalVisualProps & ModalHeaderProps & ModalBodyProps> = (args) => {
     const state = useOverlayTriggerState({});
 
     return (
@@ -154,7 +168,9 @@ const ModalTemplate: Story<ModalProps & ModalVisualProps & ModalHeaderProps> = (
                     decorator={args.decorator}
                     variant={args.variant}
                 />
-                <Modal.Body direction={ScrollWrapperDirection.Vertical}>{args.children}</Modal.Body>
+                <Modal.Body direction={ScrollWrapperDirection.Vertical} horizontalPadding={args.horizontalPadding}>
+                    {args.children}
+                </Modal.Body>
                 <Modal.Footer
                     buttons={[
                         {
@@ -203,3 +219,12 @@ Default.args = {
 export const WithLimitedText = ModalTemplate.bind({});
 
 WithLimitedText.args = { ...ModalTemplate.args, children: <ExampleParagraph /> };
+
+export const BodyWithoutHorizontalPadding = ModalTemplate.bind({});
+
+BodyWithoutHorizontalPadding.args = {
+    ...ModalTemplate.args,
+    horizontalPadding: false,
+    pattern: undefined,
+    children: <ExampleParagraph />,
+};

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -21,6 +21,7 @@ import {
     ModalWidth,
 } from "./types";
 import { FormControl, FormControlDirection, FormControlStyle } from "@components/FormControl";
+import { Divider } from "..";
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -223,13 +224,16 @@ WithLimitedText.args = { ...ModalTemplate.args, children: <ExampleParagraph /> }
 export const BodyWithoutHorizontalPadding = ModalTemplate.bind({});
 
 const ExampleFullWidthBody = () => (
-    <div
-        className={`tw-h-60 tw-bg-black-90 tw-text-white tw-overflow-y-auto ${MODAL_PADDING.top} ${MODAL_PADDING.horizontal} ${MODAL_PADDING.bottom}`}
-    >
-        <ExampleParagraph />
-        <ExampleParagraph />
-        <ExampleParagraph />
-        <ExampleParagraph />
+    <div>
+        <div className={`${MODAL_PADDING.horizontal}`}>
+            <ExampleParagraph />
+            <ExampleParagraph />
+        </div>
+        <Divider />
+        <div className={`${MODAL_PADDING.horizontal}`}>
+            <ExampleParagraph />
+            <ExampleParagraph />
+        </div>
     </div>
 );
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -85,7 +85,7 @@ const ModalComponent: FC<ModalProps> = memo((props) => {
                                 <ModalVisual {...visual} />
                             </div>
                         )}
-                        <div className="tw-flex tw-flex-col tw-flex-1 tw-space-y-6 tw-p-14 tw-overflow-hidden">
+                        <div className="tw-flex tw-flex-col tw-flex-1 tw-space-y-6 tw-overflow-hidden">
                             <ModalTitle.Provider value={titleProps}>{children}</ModalTitle.Provider>
                         </div>
                     </div>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -42,6 +42,12 @@ const widthMap: Record<ModalWidth, string> = {
     [ModalWidth.Large]: "tw-max-w-[1200px]",
 };
 
+export const MODAL_PADDING = {
+    top: "tw-pt-14",
+    horizontal: "tw-px-14",
+    bottom: "tw-pb-14",
+};
+
 const ModalComponent: FC<ModalProps> = memo((props) => {
     const { visual, children, width = ModalWidth.Default } = props;
     const ref = useRef<HTMLDivElement>(null);

--- a/src/components/Modal/ModalBody.tsx
+++ b/src/components/Modal/ModalBody.tsx
@@ -3,10 +3,14 @@
 import React, { FC } from "react";
 import { ModalBodyProps } from "./types";
 import { ScrollWrapper } from "@components/ScrollWrapper/ScrollWrapper";
+import { MODAL_PADDING } from "../..";
 
 export const ModalBody: FC<ModalBodyProps> = ({ direction, children, horizontalPadding = true }) => {
     return (
-        <div data-test-id="modal-body" className={`tw-flex-auto tw-min-h-0 ${horizontalPadding ? "tw-px-14" : ""}`}>
+        <div
+            data-test-id="modal-body"
+            className={`tw-flex-auto tw-min-h-0 ${horizontalPadding ? MODAL_PADDING.horizontal : ""}`}
+        >
             <ScrollWrapper direction={direction}>{children}</ScrollWrapper>
         </div>
     );

--- a/src/components/Modal/ModalBody.tsx
+++ b/src/components/Modal/ModalBody.tsx
@@ -4,9 +4,9 @@ import React, { FC } from "react";
 import { ModalBodyProps } from "./types";
 import { ScrollWrapper } from "@components/ScrollWrapper/ScrollWrapper";
 
-export const ModalBody: FC<ModalBodyProps> = ({ direction, children }) => {
+export const ModalBody: FC<ModalBodyProps> = ({ direction, children, horizontalPadding = true }) => {
     return (
-        <div data-test-id="modal-body" className="tw-flex-auto tw-min-h-0">
+        <div data-test-id="modal-body" className={`tw-flex-auto tw-min-h-0 ${horizontalPadding ? "tw-px-14" : ""}`}>
             <ScrollWrapper direction={direction}>{children}</ScrollWrapper>
         </div>
     );

--- a/src/components/Modal/ModalFooter.tsx
+++ b/src/components/Modal/ModalFooter.tsx
@@ -5,7 +5,7 @@ import { ModalFooterProps } from "./types";
 import { Button, ButtonSize } from "@components/Button";
 
 export const ModalFooter: FC<ModalFooterProps> = ({ buttons }) => (
-    <div data-test-id="modal-footer">
+    <div data-test-id="modal-footer" className="tw-px-14 tw-pb-14">
         {buttons && (
             <div className="tw-flex tw-gap-x-3 tw-justify-end">
                 {buttons.map((button, index) => (

--- a/src/components/Modal/ModalFooter.tsx
+++ b/src/components/Modal/ModalFooter.tsx
@@ -3,9 +3,10 @@
 import React, { FC } from "react";
 import { ModalFooterProps } from "./types";
 import { Button, ButtonSize } from "@components/Button";
+import { MODAL_PADDING } from "./Modal";
 
 export const ModalFooter: FC<ModalFooterProps> = ({ buttons }) => (
-    <div data-test-id="modal-footer" className="tw-px-14 tw-pb-14">
+    <div data-test-id="modal-footer" className={`${MODAL_PADDING.bottom} ${MODAL_PADDING.horizontal}`}>
         {buttons && (
             <div className="tw-flex tw-gap-x-3 tw-justify-end">
                 {buttons.map((button, index) => (

--- a/src/components/Modal/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader.tsx
@@ -5,6 +5,7 @@ import { merge } from "@utilities/merge";
 import { ModalHeaderProps, ModalHeaderVariant, modalHeaderVariants } from "./types";
 import { IconSize } from "@foundation/Icon";
 import { ModalTitle } from "./context/ModalTitle";
+import { MODAL_PADDING } from "./Modal";
 
 export const ModalHeader: FC<ModalHeaderProps> = ({
     title,
@@ -15,7 +16,7 @@ export const ModalHeader: FC<ModalHeaderProps> = ({
     const ariaTitleProps = useContext(ModalTitle);
 
     return (
-        <div data-test-id="modal-header" className="tw-px-14 tw-pt-14">
+        <div data-test-id="modal-header" className={`${MODAL_PADDING.top} ${MODAL_PADDING.horizontal}`}>
             <div className="tw-flex tw-items-center">
                 {decorator && (
                     <span

--- a/src/components/Modal/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader.tsx
@@ -15,7 +15,7 @@ export const ModalHeader: FC<ModalHeaderProps> = ({
     const ariaTitleProps = useContext(ModalTitle);
 
     return (
-        <div data-test-id="modal-header">
+        <div data-test-id="modal-header" className="tw-px-14 tw-pt-14">
             <div className="tw-flex tw-items-center">
                 {decorator && (
                     <span

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -42,6 +42,7 @@ type ModalBodyChildren = ReactElement | ReactElement[];
 export type ModalBodyProps = {
     direction?: ScrollWrapperDirection;
     children?: ModalBodyChildren;
+    horizontalPadding?: boolean;
 };
 
 export type ModalFooterProps = {


### PR DESCRIPTION
- moves the `tw-p-14` padding class from the `<Modal>` and reproduces that padding with classes in the Modal Body, Header, and Footer.
- adds a `horizontalPadding` class to `Modal.Body` which defaults to `true`, to remove the horizontal padding class from the `Modal.Body` wrapper `div` when set to `false`
- adds a Story for demoing the new prop