### PR TITLE
fix: prevent tooltip appearing in modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -71,8 +71,7 @@ const ModalComponent: FC<ModalProps> = memo((props) => {
             data-is-underlay={true}
             className={`tw-fixed tw-top-0 tw-left-0 tw-bottom-0 tw-right-0 tw-flex tw-justify-center tw-items-center tw-p-4`}
         >
-            {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
-            <FocusScope contain restoreFocus autoFocus>
+            <FocusScope contain restoreFocus>
                 <motion.div
                     variants={MODAL_VARIANTS}
                     className={merge([widthMap[width], "tw-w-full tw-max-h-full tw-h-contents tw-flex tw-flex-col"])}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -71,7 +71,8 @@ const ModalComponent: FC<ModalProps> = memo((props) => {
             data-is-underlay={true}
             className={`tw-fixed tw-top-0 tw-left-0 tw-bottom-0 tw-right-0 tw-flex tw-justify-center tw-items-center tw-p-4`}
         >
-            <FocusScope contain restoreFocus>
+            {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+            <FocusScope contain restoreFocus autoFocus>
                 <motion.div
                     variants={MODAL_VARIANTS}
                     className={merge([widthMap[width], "tw-w-full tw-max-h-full tw-h-contents tw-flex tw-flex-col"])}

--- a/src/components/ScrollWrapper/ScrollWrapper.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.tsx
@@ -1,7 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { useFocusRing } from "@react-aria/focus";
 import React, { FC, useRef } from "react";
-import { merge } from "../..";
+import { FOCUS_STYLE, merge } from "../..";
 import { useScrollWrapper } from "./hooks/useScrollWrapper";
 import { ScrollWrapperDirection, scrollWrapperDirections, ScrollWrapperProps } from "./types";
 
@@ -17,6 +18,8 @@ export const ScrollWrapper: FC<ScrollWrapperProps> = ({ direction = ScrollWrappe
 
     const [{ showTopShadow, showBottomShadow, showLeftShadow, showRightShadow }, scrollDivProps] =
         useScrollWrapper(scrollingContainer);
+
+    const { isFocusVisible, focusProps } = useFocusRing();
 
     const directionVertical =
         direction === ScrollWrapperDirection.Vertical || direction === ScrollWrapperDirection.Both;
@@ -42,8 +45,17 @@ export const ScrollWrapper: FC<ScrollWrapperProps> = ({ direction = ScrollWrappe
             )}
             <div
                 ref={scrollingContainer}
-                className={merge([scrollWrapperDirections[direction], "tw-flex-auto tw-min-h-0"])}
+                // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                tabIndex={0}
+                role="region"
+                aria-label="Scrollable dialogue content"
+                className={merge([
+                    scrollWrapperDirections[direction],
+                    "tw-flex-auto tw-min-h-0 tw-outline-none",
+                    isFocusVisible && FOCUS_STYLE,
+                ])}
                 {...scrollDivProps}
+                {...focusProps}
             >
                 {children}
             </div>


### PR DESCRIPTION
Prevents tooltip from automatically appearing when modal is opened, and also adds a tab-index to scrolling content so that it can be navigated via keyboard