### PR TITLE
Feat: modal compact padding option

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Modal, MODAL_PADDING } from "./Modal";
+import { Modal } from "./Modal";
 import React, { useState } from "react";
 import { Button, ButtonStyle } from "@components/Button";
 import { Story, Meta } from "@storybook/react";
@@ -16,12 +16,14 @@ import {
     ModalBodyProps,
     ModalHeaderProps,
     ModalHeaderVariant,
+    ModalPadding,
     ModalProps,
     ModalVisualProps,
     ModalWidth,
 } from "./types";
 import { FormControl, FormControlDirection, FormControlStyle } from "@components/FormControl";
 import { Divider } from "..";
+import { paddingMap } from "./context/ModalLayout";
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -97,12 +99,22 @@ export default {
             defaultValue: ModalHeaderVariant.Default,
             control: { type: "select" },
         },
+        padding: {
+            table: {
+                category: "Layout",
+            },
+            name: "Padding Size",
+            options: [ModalPadding.Default, ModalPadding.Compact],
+            control: { type: "select" },
+            defaultValue: ModalPadding.Default,
+        },
         horizontalPadding: {
             table: {
                 category: "Layout",
             },
             name: "Body Horizontal Padding",
             defaultValue: true,
+            control: { type: "boolean" },
         },
         children: {
             table: {
@@ -162,6 +174,7 @@ const ModalTemplate: Story<ModalProps & ModalVisualProps & ModalHeaderProps & Mo
                 onClose={state.close}
                 isOpen={state.isOpen}
                 isDismissable
+                padding={args.padding}
             >
                 <Modal.Header
                     title={args.title}
@@ -225,12 +238,12 @@ export const BodyWithoutHorizontalPadding = ModalTemplate.bind({});
 
 const ExampleFullWidthBody = () => (
     <div>
-        <div className={`${MODAL_PADDING.horizontal}`}>
+        <div className={`${paddingMap[ModalPadding.Default].horizontal}`}>
             <ExampleParagraph />
             <ExampleParagraph />
         </div>
         <Divider />
-        <div className={`${MODAL_PADDING.horizontal}`}>
+        <div className={`${paddingMap[ModalPadding.Default].horizontal}`}>
             <ExampleParagraph />
             <ExampleParagraph />
         </div>

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -16,14 +16,13 @@ import {
     ModalBodyProps,
     ModalHeaderProps,
     ModalHeaderVariant,
-    ModalPadding,
     ModalProps,
     ModalVisualProps,
     ModalWidth,
 } from "./types";
 import { FormControl, FormControlDirection, FormControlStyle } from "@components/FormControl";
 import { Divider } from "..";
-import { paddingMap } from "./context/ModalLayout";
+import { MODAL_PADDING } from "./context/ModalLayout";
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -99,14 +98,13 @@ export default {
             defaultValue: ModalHeaderVariant.Default,
             control: { type: "select" },
         },
-        padding: {
+        compact: {
             table: {
                 category: "Layout",
             },
-            name: "Padding Size",
-            options: [ModalPadding.Default, ModalPadding.Compact],
-            control: { type: "select" },
-            defaultValue: ModalPadding.Default,
+            name: "Compact",
+            defaultValue: false,
+            control: { type: "boolean" },
         },
         horizontalPadding: {
             table: {
@@ -174,7 +172,7 @@ const ModalTemplate: Story<ModalProps & ModalVisualProps & ModalHeaderProps & Mo
                 onClose={state.close}
                 isOpen={state.isOpen}
                 isDismissable
-                padding={args.padding}
+                compact={args.compact}
             >
                 <Modal.Header
                     title={args.title}
@@ -238,12 +236,12 @@ export const BodyWithoutHorizontalPadding = ModalTemplate.bind({});
 
 const ExampleFullWidthBody = () => (
     <div>
-        <div className={`${paddingMap[ModalPadding.Default].horizontal}`}>
+        <div className={`${MODAL_PADDING.default.horizontal}`}>
             <ExampleParagraph />
             <ExampleParagraph />
         </div>
         <Divider />
-        <div className={`${paddingMap[ModalPadding.Default].horizontal}`}>
+        <div className={`${MODAL_PADDING.default.horizontal}`}>
             <ExampleParagraph />
             <ExampleParagraph />
         </div>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@
 
 import React, { FC, memo, useRef } from "react";
 import { merge } from "@utilities/merge";
-import { ModalPadding, ModalProps, ModalWidth } from "./types";
+import { ModalProps, ModalWidth } from "./types";
 import { ModalVisual } from "./ModalVisual";
 import { OverlayContainer, useModal, useOverlay, usePreventScroll } from "@react-aria/overlays";
 import { FocusScope } from "@react-aria/focus";
@@ -12,7 +12,7 @@ import { ModalTitle } from "./context/ModalTitle";
 import { ModalHeader } from "./ModalHeader";
 import { ModalBody } from "./ModalBody";
 import { ModalFooter } from "./ModalFooter";
-import { ModalLayout, paddingMap } from "./context/ModalLayout";
+import { ModalLayout, MODAL_PADDING } from "./context/ModalLayout";
 
 const UNDERLAY_VARIANTS = {
     initial: {
@@ -46,13 +46,7 @@ const widthMap: Record<ModalWidth, string> = {
 const DEFAULT_ZINDEX = 50;
 
 const ModalComponent: FC<ModalProps> = memo((props) => {
-    const {
-        visual,
-        children,
-        width = ModalWidth.Default,
-        zIndex = DEFAULT_ZINDEX,
-        padding = ModalPadding.Default,
-    } = props;
+    const { visual, children, width = ModalWidth.Default, zIndex = DEFAULT_ZINDEX, compact = false } = props;
     const ref = useRef<HTMLDivElement>(null);
     const {
         overlayProps,
@@ -63,6 +57,8 @@ const ModalComponent: FC<ModalProps> = memo((props) => {
     const { modalProps } = useModal();
 
     const { dialogProps, titleProps } = useDialog(props, ref);
+
+    const padding = compact ? MODAL_PADDING.compact : MODAL_PADDING.default;
 
     return (
         <motion.div
@@ -98,7 +94,7 @@ const ModalComponent: FC<ModalProps> = memo((props) => {
                             </div>
                         )}
                         <div className="tw-flex tw-flex-col tw-flex-1 tw-space-y-6 tw-overflow-hidden">
-                            <ModalLayout.Provider value={{ padding: paddingMap[padding] }}>
+                            <ModalLayout.Provider value={{ compact, padding }}>
                                 <ModalTitle.Provider value={titleProps}>{children}</ModalTitle.Provider>
                             </ModalLayout.Provider>
                         </div>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@
 
 import React, { FC, memo, useRef } from "react";
 import { merge } from "@utilities/merge";
-import { ModalProps, ModalWidth } from "./types";
+import { ModalPadding, ModalProps, ModalWidth } from "./types";
 import { ModalVisual } from "./ModalVisual";
 import { OverlayContainer, useModal, useOverlay, usePreventScroll } from "@react-aria/overlays";
 import { FocusScope } from "@react-aria/focus";
@@ -12,6 +12,7 @@ import { ModalTitle } from "./context/ModalTitle";
 import { ModalHeader } from "./ModalHeader";
 import { ModalBody } from "./ModalBody";
 import { ModalFooter } from "./ModalFooter";
+import { ModalLayout, paddingMap } from "./context/ModalLayout";
 
 const UNDERLAY_VARIANTS = {
     initial: {
@@ -42,16 +43,16 @@ const widthMap: Record<ModalWidth, string> = {
     [ModalWidth.Large]: "tw-max-w-[1200px]",
 };
 
-export const MODAL_PADDING = {
-    top: "tw-pt-14",
-    horizontal: "tw-px-14",
-    bottom: "tw-pb-14",
-};
-
 const DEFAULT_ZINDEX = 50;
 
 const ModalComponent: FC<ModalProps> = memo((props) => {
-    const { visual, children, width = ModalWidth.Default, zIndex = DEFAULT_ZINDEX } = props;
+    const {
+        visual,
+        children,
+        width = ModalWidth.Default,
+        zIndex = DEFAULT_ZINDEX,
+        padding = ModalPadding.Default,
+    } = props;
     const ref = useRef<HTMLDivElement>(null);
     const {
         overlayProps,
@@ -97,7 +98,9 @@ const ModalComponent: FC<ModalProps> = memo((props) => {
                             </div>
                         )}
                         <div className="tw-flex tw-flex-col tw-flex-1 tw-space-y-6 tw-overflow-hidden">
-                            <ModalTitle.Provider value={titleProps}>{children}</ModalTitle.Provider>
+                            <ModalLayout.Provider value={{ padding: paddingMap[padding] }}>
+                                <ModalTitle.Provider value={titleProps}>{children}</ModalTitle.Provider>
+                            </ModalLayout.Provider>
                         </div>
                     </div>
                 </motion.div>

--- a/src/components/Modal/ModalBody.tsx
+++ b/src/components/Modal/ModalBody.tsx
@@ -1,15 +1,17 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC } from "react";
+import React, { FC, useContext } from "react";
 import { ModalBodyProps } from "./types";
 import { ScrollWrapper } from "@components/ScrollWrapper/ScrollWrapper";
-import { MODAL_PADDING } from "../..";
+import { ModalLayout } from "./context/ModalLayout";
 
 export const ModalBody: FC<ModalBodyProps> = ({ direction, children, horizontalPadding = true }) => {
+    const { padding } = useContext(ModalLayout);
+
     return (
         <div
             data-test-id="modal-body"
-            className={`tw-flex-auto tw-min-h-0 ${horizontalPadding ? MODAL_PADDING.horizontal : ""}`}
+            className={`tw-flex-auto tw-min-h-0 ${horizontalPadding ? padding.horizontal : ""}`}
         >
             <ScrollWrapper direction={direction}>{children}</ScrollWrapper>
         </div>

--- a/src/components/Modal/ModalFooter.tsx
+++ b/src/components/Modal/ModalFooter.tsx
@@ -1,18 +1,22 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React, { FC } from "react";
+import React, { FC, useContext } from "react";
 import { ModalFooterProps } from "./types";
 import { Button, ButtonSize } from "@components/Button";
-import { MODAL_PADDING } from "./Modal";
+import { ModalLayout } from "./context/ModalLayout";
 
-export const ModalFooter: FC<ModalFooterProps> = ({ buttons }) => (
-    <div data-test-id="modal-footer" className={`${MODAL_PADDING.bottom} ${MODAL_PADDING.horizontal}`}>
-        {buttons && (
-            <div className="tw-flex tw-gap-x-3 tw-justify-end">
-                {buttons.map((button, index) => (
-                    <Button {...button} size={ButtonSize.Medium} key={index} />
-                ))}
-            </div>
-        )}
-    </div>
-);
+export const ModalFooter: FC<ModalFooterProps> = ({ buttons }) => {
+    const { padding } = useContext(ModalLayout);
+
+    return (
+        <div data-test-id="modal-footer" className={`${padding.bottom} ${padding.horizontal}`}>
+            {buttons && (
+                <div className="tw-flex tw-gap-x-3 tw-justify-end">
+                    {buttons.map((button, index) => (
+                        <Button {...button} size={ButtonSize.Medium} key={index} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/components/Modal/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader.tsx
@@ -14,7 +14,7 @@ export const ModalHeader: FC<ModalHeaderProps> = ({
     variant = ModalHeaderVariant.Default,
 }) => {
     const ariaTitleProps = useContext(ModalTitle);
-    const { padding } = useContext(ModalLayout);
+    const { padding, compact } = useContext(ModalLayout);
 
     return (
         <div data-test-id="modal-header" className={`${padding.top} ${padding.horizontal}`}>
@@ -27,7 +27,13 @@ export const ModalHeader: FC<ModalHeaderProps> = ({
                         {cloneElement(decorator, { size: IconSize.Size24 })}
                     </span>
                 )}
-                <h3 {...ariaTitleProps} className="tw-text-xl tw-font-heading tw-font-medium tw-text-text">
+                <h3
+                    {...ariaTitleProps}
+                    className={merge([
+                        "tw-font-heading tw-font-medium tw-text-text",
+                        compact ? "tw-text-lg" : "tw-text-xl",
+                    ])}
+                >
                     {title}
                 </h3>
             </div>

--- a/src/components/Modal/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader.tsx
@@ -5,7 +5,7 @@ import { merge } from "@utilities/merge";
 import { ModalHeaderProps, ModalHeaderVariant, modalHeaderVariants } from "./types";
 import { IconSize } from "@foundation/Icon";
 import { ModalTitle } from "./context/ModalTitle";
-import { MODAL_PADDING } from "./Modal";
+import { ModalLayout } from "./context/ModalLayout";
 
 export const ModalHeader: FC<ModalHeaderProps> = ({
     title,
@@ -14,9 +14,10 @@ export const ModalHeader: FC<ModalHeaderProps> = ({
     variant = ModalHeaderVariant.Default,
 }) => {
     const ariaTitleProps = useContext(ModalTitle);
+    const { padding } = useContext(ModalLayout);
 
     return (
-        <div data-test-id="modal-header" className={`${MODAL_PADDING.top} ${MODAL_PADDING.horizontal}`}>
+        <div data-test-id="modal-header" className={`${padding.top} ${padding.horizontal}`}>
             <div className="tw-flex tw-items-center">
                 {decorator && (
                     <span

--- a/src/components/Modal/context/ModalLayout.ts
+++ b/src/components/Modal/context/ModalLayout.ts
@@ -1,19 +1,18 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { createContext } from "react";
-import { ModalPadding, ModalPaddingType } from "../types";
 
-export const paddingMap: Record<ModalPadding, ModalPaddingType> = {
-    [ModalPadding.Default]: {
+export const MODAL_PADDING = {
+    default: {
         top: "tw-pt-14",
         horizontal: "tw-px-14",
         bottom: "tw-pb-14",
     },
-    [ModalPadding.Compact]: {
+    compact: {
         top: "tw-pt-6",
         horizontal: "tw-px-6",
         bottom: "tw-pb-6",
     },
 };
 
-export const ModalLayout = createContext({ padding: paddingMap[ModalPadding.Default] });
+export const ModalLayout = createContext({ compact: false, padding: MODAL_PADDING.default });

--- a/src/components/Modal/context/ModalLayout.ts
+++ b/src/components/Modal/context/ModalLayout.ts
@@ -1,0 +1,19 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { createContext } from "react";
+import { ModalPadding, ModalPaddingType } from "../types";
+
+export const paddingMap: Record<ModalPadding, ModalPaddingType> = {
+    [ModalPadding.Default]: {
+        top: "tw-pt-14",
+        horizontal: "tw-px-14",
+        bottom: "tw-pb-14",
+    },
+    [ModalPadding.Compact]: {
+        top: "tw-pt-6",
+        horizontal: "tw-px-6",
+        bottom: "tw-pb-6",
+    },
+};
+
+export const ModalLayout = createContext({ padding: paddingMap[ModalPadding.Default] });

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -54,15 +54,8 @@ export enum ModalWidth {
     Large = "Large",
 }
 
-export enum ModalPadding {
-    Default = "Default",
-    Compact = "Compact",
-}
-
-export type ModalPaddingType = {
-    top: string;
-    horizontal: string;
-    bottom: string;
+export type ModalPadding = {
+    [key: string]: { top: string; horizontal: string; bottom: string };
 };
 
 export type ModalProps = {
@@ -71,6 +64,6 @@ export type ModalProps = {
     children?: ModalBodyChildren;
     isOpen: boolean;
     zIndex?: number;
-    padding?: ModalPadding;
+    compact?: boolean;
 } & Omit<OverlayProps, "isOpen"> &
     AriaDialogProps;

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -54,11 +54,23 @@ export enum ModalWidth {
     Large = "Large",
 }
 
+export enum ModalPadding {
+    Default = "Default",
+    Compact = "Compact",
+}
+
+export type ModalPaddingType = {
+    top: string;
+    horizontal: string;
+    bottom: string;
+};
+
 export type ModalProps = {
     visual?: ModalVisualProps;
     width?: ModalWidth;
     children?: ModalBodyChildren;
     isOpen: boolean;
     zIndex?: number;
+    padding?: ModalPadding;
 } & Omit<OverlayProps, "isOpen"> &
     AriaDialogProps;


### PR DESCRIPTION
- Adds a `padding` prop to the `<Modal>` to set either `Default` for `p-14` classes which result in 56px padding, or `Compact` for `p-6` classes which result in 24px padding. A `padding` object is distributed to Modal parts with a `layoutContext`
- Adds a storybook control for the `padding` prop and fixes the control for the `horizontalPadding` prop