### PR TITLE
fix(AssetInput): Close Menu on Upload

### DIFF
--- a/src/components/ActionMenu/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu/ActionMenu.tsx
@@ -29,6 +29,7 @@ export type ActionMenuProps = {
     focus?: FocusStrategy;
     border?: boolean;
     scrollable?: boolean;
+    onClick?: () => void;
 };
 
 export const ActionMenu = ({
@@ -37,6 +38,7 @@ export const ActionMenu = ({
     focus,
     border = true,
     scrollable = false,
+    onClick,
 }: ActionMenuProps): ReactElement<ActionMenuProps> => {
     const items = getMenuItems(menuBlocks);
     const keyItemRecord = getKeyItemRecord(items);
@@ -57,7 +59,13 @@ export const ActionMenu = ({
                 return (
                     <AriaSection key={sectionKey} ariaLabel={sectionAriaLabel}>
                         {[...section.childNodes].map((item) => (
-                            <AriaMenuItem key={item.key} menuItem={keyItemRecord[item.key]} state={state} node={item} />
+                            <AriaMenuItem
+                                key={item.key}
+                                menuItem={keyItemRecord[item.key]}
+                                state={state}
+                                node={item}
+                                onClick={onClick}
+                            />
                         ))}
                     </AriaSection>
                 );

--- a/src/components/ActionMenu/Aria/AriaMenuItem.tsx
+++ b/src/components/ActionMenu/Aria/AriaMenuItem.tsx
@@ -1,21 +1,22 @@
 import { MenuItem } from "@components/MenuItem/MenuItem";
+import { Switch, SwitchSize } from "@components/Switch";
 import { useFocusRing } from "@react-aria/focus";
 import { useMenuItem } from "@react-aria/menu";
 import { mergeProps } from "@react-aria/utils";
 import { TreeState } from "@react-stately/tree";
+import { Node } from "@react-types/shared";
 import { FOCUS_STYLE_INSET } from "@utilities/focusStyle";
 import { merge } from "@utilities/merge";
 import React, { FC, useRef, useState } from "react";
-import { ActionMenuItemType, ActionMenuSwitchItemType } from "../ActionMenu/ActionMenu";
 import { MenuItemType } from "../../Dropdown/SelectMenu/SelectMenu";
-import { Node } from "@react-types/shared";
-import { Switch, SwitchSize } from "@components/Switch";
+import { ActionMenuItemType, ActionMenuSwitchItemType } from "../ActionMenu/ActionMenu";
 
 export type AriaOptionProps = {
     menuItem: MenuItemType | ActionMenuItemType | ActionMenuSwitchItemType;
     node: Node<object>;
     isSelected?: boolean;
     state: TreeState<object>;
+    onClick?: () => void;
 };
 
 const isActionMenuItem = (
@@ -39,7 +40,7 @@ const useSwitch = (initialValue: boolean) => {
     };
 };
 
-export const AriaMenuItem: FC<AriaOptionProps> = ({ menuItem, node, state, isSelected }) => {
+export const AriaMenuItem: FC<AriaOptionProps> = ({ menuItem, node, state, isSelected, onClick }) => {
     const ref = useRef<HTMLLIElement | null>(null);
     const {
         switchComponent = undefined,
@@ -78,6 +79,7 @@ export const AriaMenuItem: FC<AriaOptionProps> = ({ menuItem, node, state, isSel
                 isFocusVisible && FOCUS_STYLE_INSET,
             ])}
             ref={ref}
+            onClick={onClick}
         >
             <MenuItem
                 title={title}

--- a/src/components/AssetInput/SingleAsset/SelectedAsset.spec.tsx
+++ b/src/components/AssetInput/SingleAsset/SelectedAsset.spec.tsx
@@ -9,6 +9,7 @@ import { SelectedAsset } from "./SelectedAsset";
 
 const SELECTED_ASSET_ID = "[data-test-id=asset-single-input]";
 const SELECTED_ASSET_FLYOUT_ID = "[data-test-id=asset-single-input-flyout]";
+const MENU_ITEM_ID = "[data-test-id=menu-item]";
 
 describe("SelectedAsset Component", () => {
     it("renders selected asset without crashing", () => {
@@ -43,5 +44,20 @@ describe("SelectedAsset Component", () => {
             $container.css("width", 300);
         });
         cy.get(SELECTED_ASSET_FLYOUT_ID).invoke("width").should("eq", 300);
+    });
+
+    it("closes on select", () => {
+        mount(
+            <SelectedAsset
+                isLoading={false}
+                asset={EXAMPLE_IMAGES[0]}
+                size={AssetInputSize.Small}
+                actions={assetInputActions}
+            />,
+        );
+        cy.get(SELECTED_ASSET_ID).click();
+
+        cy.get(MENU_ITEM_ID).first().click();
+        cy.get(MENU_ITEM_ID).should("not.exist");
     });
 });

--- a/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
+++ b/src/components/AssetInput/SingleAsset/SelectedAsset.tsx
@@ -132,7 +132,11 @@ export const SelectedAsset: FC<Required<SelectedAssetProps>> = ({ asset, size, a
                         <FocusScope restoreFocus>
                             <div {...overlayProps} ref={overlayRef}>
                                 <DismissButton onDismiss={() => menuState.close()} />
-                                <ActionMenu menuBlocks={actions} focus={focusStrategy} />
+                                <ActionMenu
+                                    menuBlocks={actions}
+                                    focus={focusStrategy}
+                                    onClick={() => menuState.close()}
+                                />
                                 <DismissButton onDismiss={() => menuState.close()} />
                             </div>
                         </FocusScope>


### PR DESCRIPTION
Fixes the following Issue:
_Asset input stays open after clicking Replace with upload and doesn't close when a file is selected and processing When the file is processed the menu appears again (Firefox)_

Ticket:
https://app.clickup.com/t/2b5ep1f