### PR TITLE
fix: Hide automatic formatter change from git blame: switching quotes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Switch to single quotes using 'npm run lint:fix'
+2c702c90e421816e4a72ec3912957cedec431bf0


### PR DESCRIPTION
- For PHPStorm a restart was needed to show the changes in annotations
- Possibly a [git config adjustment](https://michaelheap.com/git-ignore-rev/#:~:text=git%2Dblame%2Dignore%2Drevs,explain%20why%20it's%20being%20skipped.&text=Once%20the%20file%20exists%2C%20you,%2D%2Dignore%2Drevs%2Dfile%20.) is needed `git config --global blame.ignoreRevsFile .git-blame-ignore-revs`
