### PR TITLE
feat: add resize observer to Flyout

### DIFF
--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -28,14 +28,14 @@ export const FLYOUT_DIVIDER_COLOR = '#eaebeb';
 export const FLYOUT_DIVIDER_HEIGHT = '10px';
 
 export enum FlyoutPlacement {
-    Top = "top",
-    Bottom = "bottom",
-    TopLeft = "top left",
-    BottomLeft = "bottom left",
-    TopRight = "top right",
-    BottomRight = "bottom right",
-    Right = "right",
-    Left = "left",
+    Top = 'top',
+    Bottom = 'bottom',
+    TopLeft = 'top left',
+    BottomLeft = 'bottom left',
+    TopRight = 'top right',
+    BottomRight = 'bottom right',
+    Right = 'right',
+    Left = 'left',
 }
 
 export type FlyoutProps = PropsWithChildren<{
@@ -65,6 +65,7 @@ export type FlyoutProps = PropsWithChildren<{
     legacyFooter?: boolean;
     placement?: FlyoutPlacement;
     offset?: number;
+    updatePositionOnContentChange?: boolean;
 }>;
 
 export const Flyout: FC<FlyoutProps> = ({
@@ -85,6 +86,7 @@ export const Flyout: FC<FlyoutProps> = ({
     legacyFooter = true,
     placement = FlyoutPlacement.BottomLeft,
     offset,
+    updatePositionOnContentChange = false,
 }) => {
     const state = useOverlayTriggerState({ isOpen, onOpenChange });
     const { toggle, close } = state;
@@ -106,6 +108,7 @@ export const Flyout: FC<FlyoutProps> = ({
         isOpen,
         placement,
         offset,
+        updatePositionOnContentChange,
     });
 
     const { buttonProps, isPressed } = useButton({ onPress: () => toggle(), elementType: 'div' }, triggerRef);


### PR DESCRIPTION
Fixes issue with flyout recalculating flip on each render by instead setting inside of a useLayoutEffect. The Flyout will still listen to resize events on the window but it will not be buggy and change when the content changes.
An additional prop `updatePositionOnContentChange` has also been added to the Flyout to control a resizeObserver function that is called every time the height of the content changes (since this does not happen internally with react-aria). Setting this to true is useful when you have a Flyout that can contain variable content (ie. a Loading screen before a menu) and want the position to be calculated properly. The video attached contains an example of where this prop will come in useful. This prop is by default set to `false`, so components such as the `ColorPickerFlyout` will not change position when the content changes or the user changes tab inside the flyout

https://user-images.githubusercontent.com/93908356/172383807-8a8c501f-147f-4108-b817-15db48d4226f.mov
